### PR TITLE
T2: Document Extract 工具鏈與抽取（PDF/DOCX/PPTX + raw/meta/log + CLI + tests）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,15 +209,7 @@ __marimo__/
 
 # Local-only docs (do not commit)
 docs_local/
-
-# Local-only docs (do not commit)
-docs_local/
-
-# Local-only docs (do not commit)
-docs_local/
-
-# Local-only docs (do not commit)
-docs_local/
+temp/
 
 # Runtime artifacts (do not commit)
 uploads/

--- a/backend/app/services/extraction/__init__.py
+++ b/backend/app/services/extraction/__init__.py
@@ -1,0 +1,17 @@
+"""T2 document extraction services."""
+
+from app.services.extraction.pipeline import (
+    DEFAULT_OUTPUT_DIR,
+    discover_files,
+    extract_document,
+    generate_run_id,
+    run_extraction_batch,
+)
+
+__all__ = [
+    "DEFAULT_OUTPUT_DIR",
+    "discover_files",
+    "extract_document",
+    "generate_run_id",
+    "run_extraction_batch",
+]

--- a/backend/app/services/extraction/base.py
+++ b/backend/app/services/extraction/base.py
@@ -1,0 +1,22 @@
+"""Base interfaces for document extractors."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from app.services.extraction.models import ExtractionWarning, Segment
+
+
+class BaseExtractor(ABC):
+    """Contract for file-type specific extractors."""
+
+    @abstractmethod
+    def extract(
+        self,
+        file_path: Path,
+        source_path: str,
+        doc_uid: str,
+        extracted_at: str,
+    ) -> tuple[list[Segment], list[ExtractionWarning]]:
+        """Extract segments and non-fatal warnings from a document."""

--- a/backend/app/services/extraction/docx.py
+++ b/backend/app/services/extraction/docx.py
@@ -1,0 +1,69 @@
+"""DOCX extractor implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from docx import Document
+
+from app.services.extraction.base import BaseExtractor
+from app.services.extraction.models import ExtractionWarning, Segment
+
+
+class DocxExtractor(BaseExtractor):
+    def extract(
+        self,
+        file_path: Path,
+        source_path: str,
+        doc_uid: str,
+        extracted_at: str,
+    ) -> tuple[list[Segment], list[ExtractionWarning]]:
+        document = Document(str(file_path))
+        segments: list[Segment] = []
+        warnings: list[ExtractionWarning] = []
+
+        for paragraph_index, paragraph in enumerate(document.paragraphs, start=1):
+            text = paragraph.text or ""
+            locator = {"paragraph": paragraph_index}
+            segments.append(
+                Segment(
+                    segment_id=str(uuid4()),
+                    doc_uid=doc_uid,
+                    source_path=source_path,
+                    file_type="docx",
+                    unit_type="paragraph",
+                    unit_index=paragraph_index,
+                    text=text,
+                    locator=locator,
+                    extracted_at=extracted_at,
+                )
+            )
+            if not text.strip():
+                warnings.append(
+                    ExtractionWarning(
+                        code="empty_text_paragraph",
+                        message="Paragraph contains no extractable text.",
+                        locator=locator,
+                    )
+                )
+
+        if not segments:
+            warnings.append(
+                ExtractionWarning(
+                    code="docx_no_paragraphs",
+                    message="DOCX contains no paragraphs.",
+                )
+            )
+
+        if document.tables:
+            warnings.append(
+                ExtractionWarning(
+                    code="docx_tables_ignored",
+                    message=(
+                        "DOCX table cells are not extracted in T2 MVP; only paragraphs are included."
+                    ),
+                )
+            )
+
+        return segments, warnings

--- a/backend/app/services/extraction/models.py
+++ b/backend/app/services/extraction/models.py
@@ -1,0 +1,166 @@
+"""Core models for T2 document extraction pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+
+FileType = Literal["pdf", "docx", "pptx"]
+UnitType = Literal["page", "slide", "paragraph"]
+
+EXTRACTOR_VERSION = "t2-v1"
+
+
+def utc_now_iso() -> str:
+    """Return current UTC time in compact ISO8601 format."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(slots=True, frozen=True)
+class ExtractionWarning:
+    code: str
+    message: str
+    locator: dict[str, int] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.locator:
+            payload["locator"] = dict(self.locator)
+        return payload
+
+
+@dataclass(slots=True, frozen=True)
+class ExtractionError:
+    code: str
+    message: str
+    exception_type: str | None = None
+    stack_trace: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.exception_type:
+            payload["exception_type"] = self.exception_type
+        if self.stack_trace:
+            payload["stack_trace"] = self.stack_trace
+        return payload
+
+
+@dataclass(slots=True, frozen=True)
+class Segment:
+    segment_id: str
+    doc_uid: str
+    source_path: str
+    file_type: FileType
+    unit_type: UnitType
+    unit_index: int
+    text: str
+    locator: dict[str, int]
+    extracted_at: str
+    extractor_version: str = EXTRACTOR_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "segment_id": self.segment_id,
+            "doc_uid": self.doc_uid,
+            "source_path": self.source_path,
+            "file_type": self.file_type,
+            "unit_type": self.unit_type,
+            "unit_index": self.unit_index,
+            "text": self.text,
+            "locator": dict(self.locator),
+            "extracted_at": self.extracted_at,
+            "extractor_version": self.extractor_version,
+        }
+
+
+@dataclass(slots=True)
+class DocumentMeta:
+    doc_uid: str
+    filename: str
+    file_type: FileType
+    size_bytes: int
+    sha256: str
+    extracted_at: str
+    run_id: str
+    stats: dict[str, int]
+    warnings: list[ExtractionWarning] = field(default_factory=list)
+    errors: list[ExtractionError] = field(default_factory=list)
+    source_path: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "doc_uid": self.doc_uid,
+            "filename": self.filename,
+            "file_type": self.file_type,
+            "size_bytes": self.size_bytes,
+            "sha256": self.sha256,
+            "extracted_at": self.extracted_at,
+            "run_id": self.run_id,
+            "stats": dict(self.stats),
+            "warnings": [warning.to_dict() for warning in self.warnings],
+            "errors": [error.to_dict() for error in self.errors],
+        }
+        if self.source_path is not None:
+            payload["source_path"] = self.source_path
+        return payload
+
+
+@dataclass(slots=True)
+class DocumentResult:
+    source_path: str
+    file_path: Path
+    file_type: FileType
+    doc_uid: str
+    sha256: str
+    size_bytes: int
+    extracted_at: str
+    segments: list[Segment] = field(default_factory=list)
+    warnings: list[ExtractionWarning] = field(default_factory=list)
+    errors: list[ExtractionError] = field(default_factory=list)
+    log_lines: list[str] = field(default_factory=list)
+    status: Literal["success", "failed"] = "success"
+    output_dir: str | None = None
+
+    def build_meta(self, run_id: str) -> DocumentMeta:
+        non_empty_segments = sum(1 for segment in self.segments if segment.text.strip())
+        empty_segments = len(self.segments) - non_empty_segments
+        return DocumentMeta(
+            doc_uid=self.doc_uid,
+            filename=self.file_path.name,
+            file_type=self.file_type,
+            size_bytes=self.size_bytes,
+            sha256=self.sha256,
+            extracted_at=self.extracted_at,
+            run_id=run_id,
+            stats={
+                "segments": len(self.segments),
+                "non_empty_segments": non_empty_segments,
+                "empty_segments": empty_segments,
+            },
+            warnings=self.warnings,
+            errors=self.errors,
+            source_path=self.source_path,
+        )
+
+    def to_report_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "source_path": self.source_path,
+            "doc_uid": self.doc_uid,
+            "file_type": self.file_type,
+            "status": self.status,
+            "segments": len(self.segments),
+            "warnings": [warning.to_dict() for warning in self.warnings],
+            "errors": [error.to_dict() for error in self.errors],
+        }
+        if self.output_dir is not None:
+            payload["output_dir"] = self.output_dir
+        return payload

--- a/backend/app/services/extraction/pdf.py
+++ b/backend/app/services/extraction/pdf.py
@@ -1,0 +1,71 @@
+"""PDF extractor implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from pypdf import PdfReader
+
+from app.services.extraction.base import BaseExtractor
+from app.services.extraction.models import ExtractionWarning, Segment
+
+
+class PdfExtractor(BaseExtractor):
+    def extract(
+        self,
+        file_path: Path,
+        source_path: str,
+        doc_uid: str,
+        extracted_at: str,
+    ) -> tuple[list[Segment], list[ExtractionWarning]]:
+        reader = PdfReader(str(file_path))
+        segments: list[Segment] = []
+        warnings: list[ExtractionWarning] = []
+
+        for page_index, page in enumerate(reader.pages, start=1):
+            locator = {"page": page_index}
+            try:
+                text = page.extract_text() or ""
+            except Exception as exc:
+                text = ""
+                warnings.append(
+                    ExtractionWarning(
+                        code="pdf_text_extract_error",
+                        message=f"Page text extraction raised error: {exc}",
+                        locator=locator,
+                    )
+                )
+            segments.append(
+                Segment(
+                    segment_id=str(uuid4()),
+                    doc_uid=doc_uid,
+                    source_path=source_path,
+                    file_type="pdf",
+                    unit_type="page",
+                    unit_index=page_index,
+                    text=text,
+                    locator=locator,
+                    extracted_at=extracted_at,
+                )
+            )
+            if not text.strip():
+                warnings.append(
+                    ExtractionWarning(
+                        code="empty_text_page",
+                        message=(
+                            "No extractable text in page; this may be a scanned or image-based PDF."
+                        ),
+                        locator=locator,
+                    )
+                )
+
+        if not segments:
+            warnings.append(
+                ExtractionWarning(
+                    code="pdf_no_pages",
+                    message="PDF contains no pages.",
+                )
+            )
+
+        return segments, warnings

--- a/backend/app/services/extraction/pipeline.py
+++ b/backend/app/services/extraction/pipeline.py
@@ -1,0 +1,323 @@
+"""Batch extraction pipeline for T2 document processing."""
+
+from __future__ import annotations
+
+import hashlib
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+from time import monotonic
+from typing import Iterable
+from uuid import uuid4
+
+import yaml
+
+from app.services.extraction.base import BaseExtractor
+from app.services.extraction.docx import DocxExtractor
+from app.services.extraction.models import (
+    EXTRACTOR_VERSION,
+    DocumentResult,
+    ExtractionError,
+    FileType,
+    utc_now_iso,
+)
+from app.services.extraction.pdf import PdfExtractor
+from app.services.extraction.pptx import PptxExtractor
+from app.services.extraction.writer import write_batch_report, write_document_outputs
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = BACKEND_ROOT.parent
+DEFAULT_OUTPUT_DIR = BACKEND_ROOT / "datasets_local" / "raw"
+
+SUPPORTED_EXTENSIONS: dict[str, FileType] = {
+    ".pdf": "pdf",
+    ".docx": "docx",
+    ".pptx": "pptx",
+}
+
+EXTRACTORS: dict[FileType, BaseExtractor] = {
+    "pdf": PdfExtractor(),
+    "docx": DocxExtractor(),
+    "pptx": PptxExtractor(),
+}
+
+
+def generate_run_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"run-{timestamp}-{uuid4().hex[:8]}"
+
+
+def _log_line(level: str, message: str) -> str:
+    return f"{utc_now_iso()} [{level}] {message}"
+
+
+def _to_repo_relative(path: Path) -> str:
+    resolved = path.resolve()
+    for root in (REPO_ROOT, BACKEND_ROOT, Path.cwd()):
+        try:
+            return resolved.relative_to(root.resolve()).as_posix()
+        except ValueError:
+            continue
+    return resolved.as_posix()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_obj:
+        while True:
+            chunk = file_obj.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def infer_file_type(path: Path) -> FileType:
+    suffix = path.suffix.lower()
+    if suffix not in SUPPORTED_EXTENSIONS:
+        raise ValueError(f"Unsupported file type: {path}")
+    return SUPPORTED_EXTENSIONS[suffix]
+
+
+def _resolve_manifest_entry_path(manifest_path: Path, path_text: str) -> Path:
+    path_obj = Path(path_text)
+    if path_obj.is_absolute():
+        return path_obj
+
+    search_roots = [manifest_path.parent, BACKEND_ROOT, REPO_ROOT, Path.cwd()]
+    for root in search_roots:
+        candidate = (root / path_obj).resolve()
+        if candidate.exists():
+            return candidate
+
+    return (manifest_path.parent / path_obj).resolve()
+
+
+def _iter_manifest_files(manifest_path: Path) -> Iterable[Path]:
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Manifest must be a mapping object: {manifest_path}")
+
+    datasets = data.get("datasets", [])
+    if not isinstance(datasets, list):
+        raise ValueError(f"Manifest datasets must be a list: {manifest_path}")
+
+    for dataset in datasets:
+        if not isinstance(dataset, dict):
+            continue
+        files = dataset.get("files", [])
+        if not isinstance(files, list):
+            continue
+        for file_entry in files:
+            if not isinstance(file_entry, dict):
+                continue
+            relative_path = file_entry.get("relative_path")
+            if not isinstance(relative_path, str) or not relative_path.strip():
+                continue
+            resolved_path = _resolve_manifest_entry_path(manifest_path, relative_path.strip())
+            if resolved_path.suffix.lower() in SUPPORTED_EXTENSIONS:
+                yield resolved_path
+
+
+def discover_files(input_path: Path, manifest_path: Path | None = None) -> list[Path]:
+    if manifest_path is not None:
+        if not manifest_path.exists():
+            raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+
+        discovered: list[Path] = []
+        missing: list[str] = []
+        for file_path in _iter_manifest_files(manifest_path):
+            if file_path.exists() and file_path.is_file():
+                discovered.append(file_path.resolve())
+            else:
+                missing.append(file_path.as_posix())
+
+        if missing:
+            preview = ", ".join(missing[:5])
+            raise FileNotFoundError(f"Manifest includes missing files ({len(missing)}): {preview}")
+
+        unique = sorted({path.resolve() for path in discovered})
+        return unique
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input path not found: {input_path}")
+
+    if input_path.is_file():
+        infer_file_type(input_path)
+        return [input_path.resolve()]
+
+    discovered = sorted(
+        path.resolve()
+        for path in input_path.rglob("*")
+        if path.is_file() and path.suffix.lower() in SUPPORTED_EXTENSIONS
+    )
+    return discovered
+
+
+def extract_document(file_path: Path, run_id: str, source_path: str | None = None) -> DocumentResult:
+    resolved_path = file_path.resolve()
+    file_type = infer_file_type(resolved_path)
+    extracted_at = utc_now_iso()
+    source = source_path or _to_repo_relative(resolved_path)
+
+    log_lines = [
+        _log_line("INFO", f"run_id={run_id}"),
+        _log_line("INFO", f"source={source}"),
+        _log_line("INFO", f"file_type={file_type}"),
+    ]
+
+    size_bytes = resolved_path.stat().st_size
+    sha256 = _sha256_file(resolved_path)
+    doc_uid = sha256
+
+    extractor = EXTRACTORS[file_type]
+
+    try:
+        segments, warnings = extractor.extract(
+            file_path=resolved_path,
+            source_path=source,
+            doc_uid=doc_uid,
+            extracted_at=extracted_at,
+        )
+        log_lines.append(_log_line("INFO", f"segments={len(segments)} warnings={len(warnings)}"))
+        return DocumentResult(
+            source_path=source,
+            file_path=resolved_path,
+            file_type=file_type,
+            doc_uid=doc_uid,
+            sha256=sha256,
+            size_bytes=size_bytes,
+            extracted_at=extracted_at,
+            segments=segments,
+            warnings=warnings,
+            errors=[],
+            log_lines=log_lines,
+            status="success",
+        )
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        stack_trace = traceback.format_exc()
+        log_lines.append(_log_line("ERROR", f"extraction failed: {exc}"))
+        error = ExtractionError(
+            code="extract_failed",
+            message="Document extraction failed.",
+            exception_type=type(exc).__name__,
+            stack_trace=stack_trace,
+        )
+        return DocumentResult(
+            source_path=source,
+            file_path=resolved_path,
+            file_type=file_type,
+            doc_uid=doc_uid,
+            sha256=sha256,
+            size_bytes=size_bytes,
+            extracted_at=extracted_at,
+            segments=[],
+            warnings=[],
+            errors=[error],
+            log_lines=log_lines,
+            status="failed",
+        )
+
+
+def run_extraction_batch(
+    input_path: Path,
+    output_path: Path = DEFAULT_OUTPUT_DIR,
+    manifest_path: Path | None = None,
+    run_id: str | None = None,
+    fail_fast: bool = False,
+) -> dict[str, object]:
+    """Run extraction for discovered input files and write artifacts."""
+    batch_start = monotonic()
+    started_at = utc_now_iso()
+
+    current_run_id = run_id or generate_run_id()
+    output_root = output_path.resolve()
+
+    run_dir = output_root / "runs" / current_run_id
+    documents_root = run_dir / "documents"
+
+    if run_dir.exists():
+        raise FileExistsError(
+            f"Run output already exists for run_id={current_run_id}. "
+            "Use a new --run-id to preserve previous raw outputs."
+        )
+
+    documents_root.mkdir(parents=True, exist_ok=False)
+
+    files = discover_files(input_path=input_path, manifest_path=manifest_path)
+
+    results: list[DocumentResult] = []
+    seen_doc_uids: set[str] = set()
+
+    for file_path in files:
+        result = extract_document(file_path=file_path, run_id=current_run_id)
+
+        if result.doc_uid in seen_doc_uids:
+            duplicate_error = ExtractionError(
+                code="duplicate_doc_uid",
+                message=(
+                    "Duplicate doc_uid in same run; keeping first document only to avoid raw overwrite."
+                ),
+            )
+            result.status = "failed"
+            result.errors.append(duplicate_error)
+            result.log_lines.append(_log_line("ERROR", duplicate_error.message))
+            results.append(result)
+            if fail_fast:
+                break
+            continue
+
+        seen_doc_uids.add(result.doc_uid)
+
+        try:
+            doc_dir = write_document_outputs(output_root=output_root, run_id=current_run_id, result=result)
+            result.output_dir = _to_repo_relative(doc_dir)
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            result.status = "failed"
+            result.errors.append(
+                ExtractionError(
+                    code="write_failed",
+                    message="Failed to write extraction artifacts.",
+                    exception_type=type(exc).__name__,
+                    stack_trace=traceback.format_exc(),
+                )
+            )
+            result.log_lines.append(_log_line("ERROR", f"artifact write failed: {exc}"))
+
+        results.append(result)
+        if fail_fast and result.status == "failed":
+            break
+
+    finished_at = utc_now_iso()
+    duration_seconds = round(monotonic() - batch_start, 3)
+
+    success_count = sum(1 for result in results if result.status == "success")
+    failed_count = sum(1 for result in results if result.status == "failed")
+    warning_count = sum(len(result.warnings) for result in results)
+
+    report: dict[str, object] = {
+        "run_id": current_run_id,
+        "extractor_version": EXTRACTOR_VERSION,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_seconds": duration_seconds,
+        "input": _to_repo_relative(input_path),
+        "manifest": _to_repo_relative(manifest_path) if manifest_path is not None else None,
+        "output_root": _to_repo_relative(output_root),
+        "totals": {
+            "discovered_documents": len(files),
+            "processed_documents": len(results),
+            "succeeded": success_count,
+            "failed": failed_count,
+            "warnings": warning_count,
+            "stopped_early": bool(fail_fast and len(results) < len(files)),
+        },
+        "documents": [result.to_report_dict() for result in results],
+    }
+
+    report_path = output_root / "reports" / f"{current_run_id}.json"
+    report["report_path"] = _to_repo_relative(report_path)
+    write_batch_report(output_root=output_root, run_id=current_run_id, report=report)
+
+    return report

--- a/backend/app/services/extraction/pptx.py
+++ b/backend/app/services/extraction/pptx.py
@@ -1,0 +1,66 @@
+"""PPTX extractor implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from pptx import Presentation
+
+from app.services.extraction.base import BaseExtractor
+from app.services.extraction.models import ExtractionWarning, Segment
+
+
+class PptxExtractor(BaseExtractor):
+    def extract(
+        self,
+        file_path: Path,
+        source_path: str,
+        doc_uid: str,
+        extracted_at: str,
+    ) -> tuple[list[Segment], list[ExtractionWarning]]:
+        presentation = Presentation(str(file_path))
+        segments: list[Segment] = []
+        warnings: list[ExtractionWarning] = []
+
+        for slide_index, slide in enumerate(presentation.slides, start=1):
+            text_fragments: list[str] = []
+            for shape in slide.shapes:
+                if getattr(shape, "has_text_frame", False) and shape.has_text_frame:
+                    text = shape.text_frame.text or ""
+                    if text:
+                        text_fragments.append(text)
+
+            merged_text = "\n".join(text_fragments)
+            locator = {"slide": slide_index}
+            segments.append(
+                Segment(
+                    segment_id=str(uuid4()),
+                    doc_uid=doc_uid,
+                    source_path=source_path,
+                    file_type="pptx",
+                    unit_type="slide",
+                    unit_index=slide_index,
+                    text=merged_text,
+                    locator=locator,
+                    extracted_at=extracted_at,
+                )
+            )
+            if not merged_text.strip():
+                warnings.append(
+                    ExtractionWarning(
+                        code="empty_text_slide",
+                        message="Slide contains no extractable text.",
+                        locator=locator,
+                    )
+                )
+
+        if not segments:
+            warnings.append(
+                ExtractionWarning(
+                    code="pptx_no_slides",
+                    message="PPTX contains no slides.",
+                )
+            )
+
+        return segments, warnings

--- a/backend/app/services/extraction/writer.py
+++ b/backend/app/services/extraction/writer.py
@@ -1,0 +1,49 @@
+"""Writers for extraction artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.services.extraction.models import DocumentResult
+
+
+def write_document_outputs(output_root: Path, run_id: str, result: DocumentResult) -> Path:
+    """Write raw segments, document metadata, and extraction logs."""
+    doc_dir = output_root / "runs" / run_id / "documents" / result.doc_uid
+    if doc_dir.exists():
+        raise FileExistsError(f"Document output already exists for doc_uid={result.doc_uid} in run_id={run_id}")
+
+    doc_dir.mkdir(parents=True, exist_ok=False)
+
+    raw_path = doc_dir / "raw.jsonl"
+    with raw_path.open("w", encoding="utf-8") as file_obj:
+        for segment in result.segments:
+            file_obj.write(json.dumps(segment.to_dict(), ensure_ascii=False) + "\n")
+
+    meta = result.build_meta(run_id=run_id)
+    (doc_dir / "meta.json").write_text(
+        json.dumps(meta.to_dict(), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    log_content = "\n".join(result.log_lines)
+    if log_content:
+        log_content += "\n"
+    (doc_dir / "extract.log").write_text(log_content, encoding="utf-8")
+
+    return doc_dir
+
+
+def write_batch_report(output_root: Path, run_id: str, report: dict[str, Any]) -> Path:
+    """Write batch-level JSON report."""
+    reports_dir = output_root / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    report_path = reports_dir / f"{run_id}.json"
+    if report_path.exists():
+        raise FileExistsError(f"Report already exists for run_id={run_id}: {report_path}")
+
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    return report_path

--- a/backend/docs/AI_DATASETS_T2.md
+++ b/backend/docs/AI_DATASETS_T2.md
@@ -1,0 +1,121 @@
+# AI Pipeline T2 — Document Extract（Extract -> Raw Text + Metadata）
+
+此文件說明 Studydy 後端 T2 抽取流程，目標是把 `PDF/DOCX/PPTX` 轉成可供後續 T3 chunking 直接使用的穩定輸出。
+
+## 支援格式
+- `PDF`：以 page 為分段單位
+- `DOCX`：以 paragraph 為分段單位（MVP 不抽 table cells）
+- `PPTX`：以 slide 為分段單位
+
+## 抽取腳本
+- 檔案：`backend/scripts/datasets/extract_documents.py`
+
+### 常用指令
+在 repo 根目錄執行：
+
+```bash
+python backend/scripts/datasets/extract_documents.py \
+  --input backend/datasets_local/redacted \
+  --output backend/datasets_local/raw
+```
+
+測試也可在 repo root 執行：`PYTHONPATH=backend python -m pytest -q backend/tests`
+
+指定單一檔案：
+
+```bash
+python backend/scripts/datasets/extract_documents.py \
+  --input /path/to/file.docx \
+  --output backend/datasets_local/raw
+```
+
+指定 manifest（依 `datasets[*].files[*].relative_path` 抽取）：
+
+```bash
+python backend/scripts/datasets/extract_documents.py \
+  --input backend/datasets_local/redacted \
+  --manifest backend/docs/ai/datasets/manifest.v1.yaml \
+  --output backend/datasets_local/raw
+```
+
+指定 run id（避免覆蓋、利於追蹤）：
+
+```bash
+python backend/scripts/datasets/extract_documents.py \
+  --input backend/datasets_local/redacted \
+  --output backend/datasets_local/raw \
+  --run-id run-20260219T120000Z-demo
+```
+
+失敗即停止：
+
+```bash
+python backend/scripts/datasets/extract_documents.py \
+  --input backend/datasets_local/redacted \
+  --output backend/datasets_local/raw \
+  --fail-fast
+```
+
+## CLI 參數
+- `--input <path>`：資料夾或單一檔案（預設 `backend/datasets_local/redacted`）
+- `--manifest <path>`：可選；提供時以 manifest 內檔案清單為準
+- `--output <path>`：輸出根目錄（預設 `backend/datasets_local/raw`）
+- `--run-id <id>`：可選；未提供會自動生成
+- `--fail-fast`：可選；遇到第一個失敗文件即停止
+
+## 輸出結構
+
+```text
+<output>/
+  runs/<run_id>/
+    documents/<doc_uid>/
+      raw.jsonl
+      meta.json
+      extract.log
+  reports/<run_id>.json
+```
+
+## raw.jsonl（segment 一行一筆）
+每筆至少包含：
+- `segment_id`（uuid）
+- `doc_uid`（目前為檔案 `sha256`）
+- `source_path`
+- `file_type`：`pdf|docx|pptx`
+- `unit_type`：`page|slide|paragraph`
+- `unit_index`（從 1 開始）
+- `text`（可為空字串）
+- `locator`（對應 unit；例如 `{ "page": 3 }`）
+- `extracted_at`（ISO8601 UTC）
+- `extractor_version`（固定 `t2-v1`）
+
+## meta.json（document-level）
+至少包含：
+- `doc_uid`, `filename`, `file_type`, `size_bytes`, `sha256`, `extracted_at`, `run_id`
+- `stats`：`segments`, `non_empty_segments`, `empty_segments`
+- `warnings`：例如掃描型 PDF 無法抽文字、DOCX table 未抽取
+- `errors`：抽取/寫檔失敗資訊
+
+## report.json（batch-level）
+至少包含：
+- `run_id`, `started_at`, `finished_at`, `duration_seconds`
+- `totals`：`discovered_documents`, `processed_documents`, `succeeded`, `failed`, `warnings`
+- `documents`：每個文件的成功/失敗、警告、錯誤、輸出位置
+
+## Traceability 保證
+- 每個 segment 都帶有 `doc_uid + source_path + unit_index + locator`
+- PDF 可回到 page、PPTX 可回到 slide、DOCX 可回到 paragraph
+
+## Raw 永不覆蓋策略
+- 若 `run_id` 已存在，腳本會直接報錯並停止
+- 重跑請使用新 `run_id`（或不提供 `--run-id` 由系統自動生成）
+
+## 常見失敗與排查
+- 不支援格式：確認副檔名為 `.pdf/.docx/.pptx`
+- 掃描 PDF 抽不到字：`raw.jsonl` 會有空文字 segment，並在 `warnings` 標記
+- manifest 路徑錯誤：確認 `relative_path` 指向存在檔案
+- run_id 衝突：改用新 `--run-id`
+- 套件缺失：重新安裝 `backend/requirements.txt`
+
+## 安全與提交注意事項
+- `datasets_local` 只供本機資料管線使用，不提交實際抽取產物
+- 禁止提交任何 secrets（`.env`、金鑰、連線字串等）

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,6 @@ itsdangerous
 python-multipart
 jsonschema>=4.0.0
 PyYAML>=6.0.1
+pypdf
+python-docx
+python-pptx

--- a/backend/scripts/datasets/extract_documents.py
+++ b/backend/scripts/datasets/extract_documents.py
@@ -1,0 +1,95 @@
+"""CLI entrypoint for T2 document extraction pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.services.extraction.pipeline import DEFAULT_OUTPUT_DIR, run_extraction_batch
+
+
+DEFAULT_INPUT_DIR = BACKEND_ROOT / "datasets_local" / "redacted"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extract PDF/DOCX/PPTX into raw segment JSONL + metadata + report."
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=DEFAULT_INPUT_DIR,
+        help=f"Input file or directory (default: {DEFAULT_INPUT_DIR})",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="Optional dataset manifest path; when provided, files are loaded from manifest entries.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Output root path (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default=None,
+        help="Optional run id. If omitted, a UTC-based run id is generated.",
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop processing after first failed document.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        report = run_extraction_batch(
+            input_path=args.input,
+            output_path=args.output,
+            manifest_path=args.manifest,
+            run_id=args.run_id,
+            fail_fast=args.fail_fast,
+        )
+    except Exception as exc:
+        print(f"Extraction failed before completion: {exc}", file=sys.stderr)
+        return 2
+
+    totals = report.get("totals", {})
+    failed = int(totals.get("failed", 0))
+    succeeded = int(totals.get("succeeded", 0))
+    warnings = int(totals.get("warnings", 0))
+
+    print(
+        json.dumps(
+            {
+                "run_id": report.get("run_id"),
+                "succeeded": succeeded,
+                "failed": failed,
+                "warnings": warnings,
+                "report_path": report.get("report_path"),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+    return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,5 @@
+import sys
+from pathlib import Path
 from typing import AsyncGenerator, Tuple
 
 import httpx
@@ -5,6 +7,11 @@ import pytest
 from httpx import ASGITransport
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_ROOT_STR = str(BACKEND_ROOT)
+if BACKEND_ROOT_STR not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT_STR)
 
 from app import db
 from app.db import get_session

--- a/backend/tests/test_extract_documents_cli.py
+++ b/backend/tests/test_extract_documents_cli.py
@@ -1,0 +1,80 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from docx import Document
+
+
+BASE = Path(__file__).resolve().parents[1]
+SCRIPT = BASE / "scripts" / "datasets" / "extract_documents.py"
+
+
+def _build_docx(path: Path) -> None:
+    document = Document()
+    document.add_paragraph("CLI smoke paragraph")
+    document.save(path)
+
+
+def test_extract_documents_cli_smoke(tmp_path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir(parents=True, exist_ok=True)
+
+    docx_path = input_dir / "cli-smoke.docx"
+    _build_docx(docx_path)
+
+    run_id = "test-run-cli-smoke"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--input",
+            str(input_dir),
+            "--output",
+            str(output_dir),
+            "--run-id",
+            run_id,
+        ],
+        cwd=BASE,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report_path = output_dir / "reports" / f"{run_id}.json"
+    assert report_path.exists()
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["run_id"] == run_id
+    assert report["totals"]["discovered_documents"] == 1
+    assert report["totals"]["processed_documents"] == 1
+    assert report["totals"]["succeeded"] == 1
+    assert report["totals"]["failed"] == 0
+
+    doc_uid = report["documents"][0]["doc_uid"]
+    document_dir = output_dir / "runs" / run_id / "documents" / doc_uid
+    raw_path = document_dir / "raw.jsonl"
+    meta_path = document_dir / "meta.json"
+    log_path = document_dir / "extract.log"
+
+    assert raw_path.exists()
+    assert meta_path.exists()
+    assert log_path.exists()
+
+    raw_lines = [line for line in raw_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(raw_lines) == 1
+
+    raw_record = json.loads(raw_lines[0])
+    assert raw_record["file_type"] == "docx"
+    assert raw_record["unit_type"] == "paragraph"
+    assert raw_record["unit_index"] == 1
+    assert raw_record["text"] == "CLI smoke paragraph"
+
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert meta["run_id"] == run_id
+    assert meta["stats"]["segments"] == 1
+    assert meta["stats"]["non_empty_segments"] == 1
+    assert meta["stats"]["empty_segments"] == 0

--- a/backend/tests/test_extraction_extractors.py
+++ b/backend/tests/test_extraction_extractors.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+
+from docx import Document
+from pypdf import PdfWriter
+from pptx import Presentation
+from pptx.util import Inches
+
+from app.services.extraction.pipeline import extract_document
+
+
+def _build_pdf(path: Path) -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=300, height=300)
+    with path.open("wb") as file_obj:
+        writer.write(file_obj)
+
+
+def _build_docx(path: Path) -> None:
+    document = Document()
+    document.add_paragraph("DOCX paragraph one")
+    document.add_paragraph("DOCX paragraph two")
+    document.save(path)
+
+
+def _build_pptx(path: Path) -> None:
+    presentation = Presentation()
+    blank_layout = presentation.slide_layouts[6] if len(presentation.slide_layouts) > 6 else presentation.slide_layouts[-1]
+
+    slide_1 = presentation.slides.add_slide(blank_layout)
+    textbox_1 = slide_1.shapes.add_textbox(Inches(1), Inches(1), Inches(6), Inches(1))
+    textbox_1.text_frame.text = "PPTX slide one text"
+
+    slide_2 = presentation.slides.add_slide(blank_layout)
+    textbox_2 = slide_2.shapes.add_textbox(Inches(1), Inches(1), Inches(6), Inches(1))
+    textbox_2.text_frame.text = "PPTX slide two text"
+
+    presentation.save(path)
+
+
+def test_pdf_extractor_returns_page_segments_and_warnings(tmp_path) -> None:
+    pdf_path = tmp_path / "sample.pdf"
+    _build_pdf(pdf_path)
+
+    result = extract_document(pdf_path, run_id="test-run")
+
+    assert result.status == "success"
+    assert result.file_type == "pdf"
+    assert result.doc_uid == result.sha256
+    assert len(result.segments) == 1
+    assert result.segments[0].unit_type == "page"
+    assert result.segments[0].unit_index == 1
+    assert result.segments[0].locator == {"page": 1}
+    assert result.segments[0].text == ""
+    assert any(warning.code == "empty_text_page" for warning in result.warnings)
+
+    rerun = extract_document(pdf_path, run_id="test-run-rerun")
+    assert rerun.doc_uid == result.doc_uid
+
+
+def test_docx_extractor_returns_paragraph_segments(tmp_path) -> None:
+    docx_path = tmp_path / "sample.docx"
+    _build_docx(docx_path)
+
+    result = extract_document(docx_path, run_id="test-run")
+
+    assert result.status == "success"
+    assert result.file_type == "docx"
+    assert result.doc_uid == result.sha256
+    assert [segment.unit_index for segment in result.segments] == [1, 2]
+    assert [segment.locator for segment in result.segments] == [{"paragraph": 1}, {"paragraph": 2}]
+    assert [segment.text for segment in result.segments] == ["DOCX paragraph one", "DOCX paragraph two"]
+    assert result.warnings == []
+
+
+def test_pptx_extractor_returns_slide_segments(tmp_path) -> None:
+    pptx_path = tmp_path / "sample.pptx"
+    _build_pptx(pptx_path)
+
+    result = extract_document(pptx_path, run_id="test-run")
+
+    assert result.status == "success"
+    assert result.file_type == "pptx"
+    assert result.doc_uid == result.sha256
+    assert [segment.unit_index for segment in result.segments] == [1, 2]
+    assert [segment.locator for segment in result.segments] == [{"slide": 1}, {"slide": 2}]
+    assert "PPTX slide one text" in result.segments[0].text
+    assert "PPTX slide two text" in result.segments[1].text
+    assert result.warnings == []
+
+
+
+def test_extract_result_serialization_is_json_safe(tmp_path) -> None:
+    docx_path = tmp_path / "sample.docx"
+    _build_docx(docx_path)
+
+    result = extract_document(docx_path, run_id="test-run")
+    payload = result.to_report_dict()
+
+    serialized = json.dumps(payload)
+    assert serialized


### PR DESCRIPTION


### 變更摘要

完成 AI 流程 **T2（Document Extract）** 工程化落地：新增文件抽取 library、CLI、pytest 測試與文件，支援 **PDF/DOCX/PPTX** 抽取，輸出 **raw 不覆蓋**且具備**可追溯 metadata** 的產物（raw.jsonl / meta.json / extract.log / report.json），供後續 **T3 chunking** 直接使用。

### 主要變更

* **本機資料集保護**

  * `backend/datasets_local/**` 全面 gitignore（僅追蹤 `.gitkeep`），避免提交任何教材或抽取產物。
* **T2 規範文件**

  * 新增 `backend/docs/AI_DATASETS_T2.md`：說明抽取流程、輸出結構、欄位契約、常見問題。
* **抽取 Library（可重用）**

  * 新增 `backend/app/services/extraction/`：

    * `base.py`：抽取器介面
    * `pdf.py` / `docx.py` / `pptx.py`：各格式抽取器
    * `pipeline.py`：dispatch + batch runner（input 資料夾/單檔、run_id、防覆蓋策略）
    * `writer.py`：輸出 raw.jsonl / meta.json / extract.log / report.json
    * `models.py`：固定 schema（segment / meta / report）
* **CLI（批次抽取）**

  * 新增 `backend/scripts/datasets/extract_documents.py`
  * 支援資料夾或單檔輸入，產生 `run_id`，輸出到 `backend/datasets_local/raw`（或指定 output）
* **輸出契約（T3 可直接接）**

  * `raw.jsonl`：固定 segment 欄位（含 `segment_id/doc_uid/source_path/file_type/unit_type/unit_index/text/locator/extracted_at/extractor_version`）
  * `meta.json`：文件層級 meta（含 `doc_uid/sha256/size_bytes/stats/warnings/errors/run_id`）
  * `extract.log`：逐文件抽取 log
  * `reports/<run_id>.json`：批次摘要（totals/documents/duration 等）
  * **同一 run_id 若重跑不覆蓋既有 raw**（以 run 目錄隔離）
* **測試**

  * 新增 `backend/tests/test_extraction_extractors.py`：PDF/DOCX/PPTX 抽取器測試
  * 新增 `backend/tests/test_extract_documents_cli.py`：CLI smoke test
  * 新增 `backend/tests/conftest.py`：修正從 repo root 執行測試時的 import path（避免 `ModuleNotFoundError: app`）
* **依賴**

  * 更新 `backend/requirements.txt`：新增 `pypdf`、`python-docx`、`python-pptx`

### 為什麼要改

* T2 是後續 T3（chunking）與訓練資料管線的入口：必須先把各格式文件抽成**穩定、可回溯、可批次處理**的 raw segments。
* 抽取階段保留「raw 不覆蓋」與完整 locator/metadata，可在後續切塊、清洗或追查錯誤時回到原始位置，降低資料不可重現風險。

### 如何驗證（本地測試）

在 repo root：

```bash
python -m pip install -r backend/requirements.txt
python -m pytest -q backend/tests
python backend/scripts/datasets/extract_documents.py --input backend/datasets_local/redacted --output backend/datasets_local/raw
python backend/scripts/datasets/extract_documents.py --input /tmp/studydy_t2_demo/demo.docx --output backend/datasets_local/raw
```

或在 backend/：

```bash
cd backend
python -m pip install -r requirements.txt
python -m pytest -q
```

### 安全/合規確認

* 未提交任何真實教材檔案（PDF/DOCX/PPTX 等）或抽取產物（jsonl/log/report）
* 未提交任何 secrets（.env、keys、token、連線字串等）
* `datasets_local/` 僅保留 `.gitkeep` 供目錄骨架使用

### 檢查清單

- [ ] `datasets_local/` 只有 `.gitkeep` 被追蹤（無教材內容 / 無抽取產物）
- [ ] CLI 可對資料夾/單檔成功抽取並產出 `raw.jsonl/meta.json/extract.log/report.json`
- [ ]  segment/meta schema 固定且可被 T3 直接使用
- [ ]  `pytest` 全部通過（repo root 與 backend 內皆可重現）
