### PR TITLE
T3: Chunk -> Intermediate JSONL（chunking CLI + schema/docs + tests）

### DIFF
--- a/backend/docs/ai/datasets/chunking_rules.v1.md
+++ b/backend/docs/ai/datasets/chunking_rules.v1.md
@@ -1,0 +1,106 @@
+# Chunking Rules v1 (Chunk -> Intermediate)
+
+## Input / Output
+- Manifest input: `backend/docs/ai/datasets/manifest.v1.yaml`
+- Chunk output dir: `backend/datasets_local/exports/chunks`
+- Per-dataset JSONL: `{dataset_id}.chunks.v1.jsonl`
+- Stats output: `chunk_stats.v1.json`
+
+> `datasets_local` 產物為本機資料，不應提交到版本庫（`.gitignore` 只允許 `.gitkeep`）。
+
+## Source Selection (raw/redacted)
+- 逐一讀取 manifest 的 `datasets[*].files[*]`。
+- 以 manifest 的 `files[].relative_path` 當 traceability source key。
+- 實際讀檔時優先 redacted：若 `datasets_local/redacted/` 存在同路徑或同檔名檔案則使用它，否則使用 raw。
+
+## Supported Formats & Unit Boundaries
+- `pdf` (pypdf): 以 page 為 unit（1-based）
+- `docx` (python-docx): 以 paragraph 為 unit（0-based）
+- `pptx` (python-pptx): 以 slide 為 unit（1-based）
+- `txt` / `md`: 以空行切段為 paragraph unit（0-based）
+
+## Chunking Parameters
+- `max_chars`：預設 `1200`（可 CLI 覆寫）
+- `min_chars`：預設 `200`（可 CLI 覆寫）
+- `overlap_chars`：預設 `0`（可 CLI 覆寫）
+
+規則：
+1. 優先保持 unit 邊界（paragraph/page/slide）合併，避免破壞追溯性。
+2. 若單一 unit 超過 `max_chars`，允許 unit 內切分：
+   - 先找換行
+   - 再找句尾標點（`. ? !` 與 `。？！`）
+   - 最後才硬切
+3. 盡量避免過小 chunk；若可在不超過 `max_chars` 前提下，會合併小於 `min_chars` 的鄰近 chunk。
+
+## Chunk Record Schema (JSONL each line)
+每筆至少包含：
+- `chunk_id`: `ch-{dataset_id}-{seq:06d}`
+- `text`: chunk text
+- `meta` (object):
+  - required:
+    - `source_relative_path` (manifest 的 `files[].relative_path`)
+    - `file_type`
+    - `sha256`
+    - `dataset_id`
+    - `created_at` (UTC ISO8601)
+    - `char_count`
+  - traceability (依格式):
+    - PDF: `page_start`, `page_end`
+    - DOCX/TXT/MD: `paragraph_start`, `paragraph_end`
+    - PPTX: `slide_start`, `slide_end`
+  - optional:
+    - `title`
+    - `heading`
+
+完整 schema 參考：
+- `backend/docs/ai/datasets/document_chunks.schema.v1.json`
+
+## Stats (`chunk_stats.v1.json`)
+至少包含：
+- `datasets.{dataset_id}.chunk_count`
+- `datasets.{dataset_id}.total_chars`
+- `datasets.{dataset_id}.avg_chars`
+- `datasets.{dataset_id}.min_chars`
+- `datasets.{dataset_id}.max_chars`
+
+並包含整體 totals（dataset_count / chunk_count / total_chars）。
+
+## CLI
+Script:
+- `backend/scripts/datasets/build_chunks.py`
+
+常用指令（在 repo root）：
+
+```bash
+python backend/scripts/datasets/build_chunks.py
+```
+
+指定 manifest / output：
+
+```bash
+python backend/scripts/datasets/build_chunks.py \
+  --manifest backend/docs/ai/datasets/manifest.v1.yaml \
+  --out-dir backend/datasets_local/exports/chunks
+```
+
+覆寫 chunk 參數：
+
+```bash
+python backend/scripts/datasets/build_chunks.py \
+  --max-chars 1000 \
+  --min-chars 180 \
+  --overlap-chars 0
+```
+
+僅跑單一 dataset：
+
+```bash
+python backend/scripts/datasets/build_chunks.py \
+  --dataset-id ds-example
+```
+
+Dry run（只印統計，不寫檔）：
+
+```bash
+python backend/scripts/datasets/build_chunks.py --dry-run
+```

--- a/backend/docs/ai/datasets/document_chunks.schema.v1.json
+++ b/backend/docs/ai/datasets/document_chunks.schema.v1.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studydy.local/schemas/document_chunks.schema.v1.json",
+  "title": "Studydy Document Chunk Record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "chunk_id",
+    "text",
+    "meta"
+  ],
+  "properties": {
+    "chunk_id": {
+      "type": "string",
+      "pattern": "^ch-[a-zA-Z0-9][a-zA-Z0-9\\-_]*-\\d{6}$"
+    },
+    "text": {
+      "type": "string",
+      "minLength": 1
+    },
+    "meta": {
+      "$ref": "#/$defs/meta"
+    }
+  },
+  "$defs": {
+    "meta": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "source_relative_path",
+        "file_type",
+        "sha256",
+        "dataset_id",
+        "created_at",
+        "char_count"
+      ],
+      "properties": {
+        "source_relative_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "file_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "dataset_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_at": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+        },
+        "char_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "page_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "page_end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "paragraph_start": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "paragraph_end": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "slide_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "slide_end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "title": {
+          "type": "string"
+        },
+        "heading": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "page_start",
+                "page_end"
+              ]
+            },
+            {
+              "required": [
+                "paragraph_start",
+                "paragraph_end"
+              ]
+            },
+            {
+              "required": [
+                "slide_start",
+                "slide_end"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/backend/scripts/datasets/build_chunks.py
+++ b/backend/scripts/datasets/build_chunks.py
@@ -1,0 +1,685 @@
+# backend/scripts/datasets/build_chunks.py
+"""Build dataset chunks (T3) from manifest entries into intermediate JSONL."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+from docx import Document
+from pypdf import PdfReader
+from pptx import Presentation
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST_PATH = BACKEND_ROOT / "docs" / "ai" / "datasets" / "manifest.v1.yaml"
+DEFAULT_OUT_DIR = BACKEND_ROOT / "datasets_local" / "exports" / "chunks"
+
+SUPPORTED_SUFFIXES = {".pdf", ".docx", ".pptx", ".txt", ".md"}
+PUNCTUATION_BREAKS = {"。", "！", "？", ".", "!", "?"}
+
+
+@dataclass(slots=True, frozen=True)
+class Unit:
+    text: str
+    start: int
+    end: int
+    heading: str | None = None
+    title: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class ChunkSpan:
+    text: str
+    start: int
+    end: int
+    heading: str | None = None
+    title: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class ExtractedFile:
+    units: list[Unit]
+    locator_key: str
+    heading: str | None
+    title: str | None
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Manifest must be a mapping object: {path}")
+    return data
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_obj:
+        while True:
+            chunk = file_obj.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _infer_backend_root(manifest_path: Path) -> Path:
+    for candidate in [manifest_path.parent, *manifest_path.parents]:
+        if candidate.name == "backend":
+            return candidate.resolve()
+    return BACKEND_ROOT
+
+
+def _candidate_roots(manifest_path: Path) -> list[Path]:
+    backend_root = _infer_backend_root(manifest_path)
+    roots = [
+        manifest_path.parent.resolve(),
+        backend_root,
+        backend_root.parent.resolve(),
+        BACKEND_ROOT,
+        BACKEND_ROOT.parent.resolve(),
+        Path.cwd().resolve(),
+    ]
+
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        key = root.as_posix()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(root)
+    return unique
+
+
+def _resolve_manifest_entry_path(manifest_path: Path, path_text: str) -> Path:
+    path_obj = Path(path_text)
+    if path_obj.is_absolute():
+        return path_obj.resolve()
+
+    for root in _candidate_roots(manifest_path):
+        candidate = (root / path_obj).resolve()
+        if candidate.exists():
+            return candidate
+
+    return (_candidate_roots(manifest_path)[0] / path_obj).resolve()
+
+
+def _find_redacted_file(raw_path: Path, backend_root: Path) -> Path:
+    redacted_root = backend_root / "datasets_local" / "redacted"
+    raw_root = backend_root / "datasets_local" / "raw"
+    if not redacted_root.exists():
+        return raw_path
+
+    try:
+        relative_under_raw = raw_path.resolve().relative_to(raw_root.resolve())
+        candidate = (redacted_root / relative_under_raw).resolve()
+        if candidate.exists() and candidate.is_file():
+            return candidate
+    except ValueError:
+        pass
+
+    direct_candidate = (redacted_root / raw_path.name).resolve()
+    if direct_candidate.exists() and direct_candidate.is_file():
+        return direct_candidate
+
+    same_name = sorted(path for path in redacted_root.rglob(raw_path.name) if path.is_file())
+    if same_name:
+        return same_name[0].resolve()
+
+    return raw_path.resolve()
+
+
+def _read_text_file(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="latin-1")
+
+
+def _extract_text_units(path: Path, *, markdown: bool) -> ExtractedFile:
+    content = _read_text_file(path)
+    lines = content.splitlines()
+
+    title: str | None = None
+    heading: str | None = None
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if title is None:
+            title = stripped.lstrip("# ").strip() if stripped.startswith("#") else stripped
+        if markdown and heading is None and stripped.startswith("#"):
+            heading = stripped.lstrip("# ").strip()
+        if title is not None and (heading is not None or not markdown):
+            break
+
+    units: list[Unit] = []
+    paragraph_lines: list[str] = []
+    paragraph_index = 0
+
+    def flush_paragraph() -> None:
+        nonlocal paragraph_index
+        if not paragraph_lines:
+            return
+        text = "\n".join(paragraph_lines).strip()
+        units.append(Unit(text=text, start=paragraph_index, end=paragraph_index, heading=heading, title=title))
+        paragraph_lines.clear()
+        paragraph_index += 1
+
+    for line in lines:
+        if not line.strip():
+            flush_paragraph()
+            continue
+        paragraph_lines.append(line.rstrip())
+
+    flush_paragraph()
+    return ExtractedFile(units=units, locator_key="paragraph", heading=heading, title=title)
+
+
+def _extract_docx_units(path: Path) -> ExtractedFile:
+    document = Document(str(path))
+    heading: str | None = None
+    title: str | None = None
+    units: list[Unit] = []
+
+    for paragraph_index, paragraph in enumerate(document.paragraphs):
+        text = paragraph.text or ""
+        stripped = text.strip()
+        style_name = (paragraph.style.name or "").strip().lower() if paragraph.style is not None else ""
+
+        if title is None and stripped:
+            title = stripped
+        if heading is None and stripped and style_name.startswith("heading"):
+            heading = stripped
+
+        units.append(
+            Unit(
+                text=text,
+                start=paragraph_index,
+                end=paragraph_index,
+                heading=heading,
+                title=title,
+            )
+        )
+
+    return ExtractedFile(units=units, locator_key="paragraph", heading=heading, title=title)
+
+
+def _extract_pptx_units(path: Path) -> ExtractedFile:
+    presentation = Presentation(str(path))
+    heading: str | None = None
+    title = (presentation.core_properties.title or "").strip() or None
+    units: list[Unit] = []
+
+    for slide_index, slide in enumerate(presentation.slides, start=1):
+        fragments: list[str] = []
+        slide_heading: str | None = None
+
+        if slide.shapes.title is not None:
+            candidate = (slide.shapes.title.text or "").strip()
+            if candidate:
+                slide_heading = candidate
+                if heading is None:
+                    heading = candidate
+                if title is None:
+                    title = candidate
+
+        for shape in slide.shapes:
+            if not getattr(shape, "has_text_frame", False) or not shape.has_text_frame:
+                continue
+            text = shape.text_frame.text or ""
+            if text.strip():
+                fragments.append(text.strip())
+
+        units.append(
+            Unit(
+                text="\n".join(fragments),
+                start=slide_index,
+                end=slide_index,
+                heading=slide_heading or heading,
+                title=title,
+            )
+        )
+
+    return ExtractedFile(units=units, locator_key="slide", heading=heading, title=title)
+
+
+def _extract_pdf_units(path: Path) -> ExtractedFile:
+    reader = PdfReader(str(path))
+    metadata_title = None
+    if reader.metadata is not None:
+        metadata_title = str(reader.metadata.title or "").strip() or None
+
+    units: list[Unit] = []
+    for page_index, page in enumerate(reader.pages, start=1):
+        try:
+            text = page.extract_text() or ""
+        except Exception:
+            text = ""
+        units.append(Unit(text=text, start=page_index, end=page_index, title=metadata_title))
+
+    return ExtractedFile(units=units, locator_key="page", heading=None, title=metadata_title)
+
+
+def extract_units(path: Path) -> ExtractedFile:
+    suffix = path.suffix.lower()
+    if suffix == ".pdf":
+        return _extract_pdf_units(path)
+    if suffix == ".docx":
+        return _extract_docx_units(path)
+    if suffix == ".pptx":
+        return _extract_pptx_units(path)
+    if suffix == ".txt":
+        return _extract_text_units(path, markdown=False)
+    if suffix == ".md":
+        return _extract_text_units(path, markdown=True)
+    raise ValueError(f"Unsupported file suffix for chunking: {path.suffix}")
+
+
+def _find_cut_index(window: str, min_chars: int) -> int:
+    lower_bound = max(1, min_chars)
+    for index in range(len(window) - 1, lower_bound - 1, -1):
+        if window[index] == "\n":
+            return index + 1
+    for index in range(len(window) - 1, lower_bound - 1, -1):
+        if window[index] in PUNCTUATION_BREAKS:
+            return index + 1
+    return len(window)
+
+
+def split_long_text(text: str, max_chars: int, min_chars: int) -> list[str]:
+    cleaned = text.strip()
+    if not cleaned:
+        return []
+    if len(cleaned) <= max_chars:
+        return [cleaned]
+
+    result: list[str] = []
+    cursor = 0
+    while cursor < len(cleaned):
+        remaining = cleaned[cursor:]
+        if len(remaining) <= max_chars:
+            piece = remaining.strip()
+            if piece:
+                result.append(piece)
+            break
+
+        window = cleaned[cursor : cursor + max_chars]
+        cut = _find_cut_index(window, min_chars=min_chars)
+        piece = cleaned[cursor : cursor + cut].strip()
+        if not piece:
+            cut = max_chars
+            piece = cleaned[cursor : cursor + cut].strip()
+        if piece:
+            result.append(piece)
+        cursor += cut
+
+    if len(result) >= 2 and len(result[-1]) < min_chars:
+        merged = f"{result[-2]}\n{result[-1]}".strip()
+        if len(merged) <= max_chars:
+            result[-2] = merged
+            result.pop()
+
+    return result
+
+
+def build_spans(
+    units: list[Unit],
+    *,
+    max_chars: int,
+    min_chars: int,
+    overlap_chars: int,
+) -> list[ChunkSpan]:
+    if max_chars <= 0:
+        raise ValueError("max_chars must be > 0")
+    if min_chars < 0:
+        raise ValueError("min_chars must be >= 0")
+    if min_chars > max_chars:
+        raise ValueError("min_chars cannot be greater than max_chars")
+    if overlap_chars < 0:
+        raise ValueError("overlap_chars must be >= 0")
+
+    segments: list[ChunkSpan] = []
+    for unit in units:
+        unit_text = (unit.text or "").strip()
+        if not unit_text:
+            continue
+        pieces = split_long_text(unit_text, max_chars=max_chars, min_chars=min_chars)
+        for piece in pieces:
+            segments.append(
+                ChunkSpan(
+                    text=piece,
+                    start=unit.start,
+                    end=unit.end,
+                    heading=unit.heading,
+                    title=unit.title,
+                )
+            )
+
+    chunks: list[ChunkSpan] = []
+    current: ChunkSpan | None = None
+
+    for segment in segments:
+        if current is None:
+            current = segment
+            continue
+
+        merged_text = f"{current.text}\n\n{segment.text}"
+        if len(merged_text) <= max_chars:
+            current = ChunkSpan(
+                text=merged_text,
+                start=current.start,
+                end=segment.end,
+                heading=current.heading or segment.heading,
+                title=current.title or segment.title,
+            )
+        else:
+            chunks.append(current)
+            current = segment
+
+    if current is not None:
+        chunks.append(current)
+
+    if min_chars > 0 and len(chunks) >= 2:
+        index = 0
+        while index < len(chunks) - 1:
+            if len(chunks[index].text) < min_chars:
+                merged_text = f"{chunks[index].text}\n\n{chunks[index + 1].text}"
+                if len(merged_text) <= max_chars:
+                    chunks[index] = ChunkSpan(
+                        text=merged_text,
+                        start=chunks[index].start,
+                        end=chunks[index + 1].end,
+                        heading=chunks[index].heading or chunks[index + 1].heading,
+                        title=chunks[index].title or chunks[index + 1].title,
+                    )
+                    chunks.pop(index + 1)
+                    continue
+            index += 1
+
+        if len(chunks) >= 2 and len(chunks[-1].text) < min_chars:
+            merged_tail = f"{chunks[-2].text}\n\n{chunks[-1].text}"
+            if len(merged_tail) <= max_chars:
+                chunks[-2] = ChunkSpan(
+                    text=merged_tail,
+                    start=chunks[-2].start,
+                    end=chunks[-1].end,
+                    heading=chunks[-2].heading or chunks[-1].heading,
+                    title=chunks[-2].title or chunks[-1].title,
+                )
+                chunks.pop()
+
+    if overlap_chars > 0 and len(chunks) >= 2:
+        overlapped: list[ChunkSpan] = [chunks[0]]
+        for index in range(1, len(chunks)):
+            previous = overlapped[-1]
+            current_chunk = chunks[index]
+            overlap = previous.text[-overlap_chars:] if previous.text else ""
+            if overlap:
+                candidate = f"{overlap}\n{current_chunk.text}"
+                text = candidate if len(candidate) <= max_chars else current_chunk.text
+            else:
+                text = current_chunk.text
+            overlapped.append(
+                ChunkSpan(
+                    text=text,
+                    start=current_chunk.start,
+                    end=current_chunk.end,
+                    heading=current_chunk.heading,
+                    title=current_chunk.title,
+                )
+            )
+        chunks = overlapped
+
+    return chunks
+
+
+def _ensure_supported(path: Path) -> None:
+    if path.suffix.lower() not in SUPPORTED_SUFFIXES:
+        raise ValueError(f"Unsupported file type for T3 chunking: {path}")
+
+
+def build_dataset_chunks(
+    *,
+    manifest_path: Path,
+    max_chars: int,
+    min_chars: int,
+    overlap_chars: int,
+    dataset_id_filter: str | None,
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, Any]]:
+    manifest = load_manifest(manifest_path)
+    datasets = manifest.get("datasets", [])
+    if not isinstance(datasets, list):
+        raise ValueError("Manifest field `datasets` must be an array")
+
+    selected = []
+    for dataset in datasets:
+        if not isinstance(dataset, dict):
+            continue
+        dataset_id = dataset.get("dataset_id")
+        if not isinstance(dataset_id, str) or not dataset_id.strip():
+            continue
+        if dataset_id_filter is not None and dataset_id != dataset_id_filter:
+            continue
+        selected.append(dataset)
+
+    if dataset_id_filter is not None and not selected:
+        raise ValueError(f"Dataset id not found in manifest: {dataset_id_filter}")
+
+    backend_root = _infer_backend_root(manifest_path)
+    created_at = utc_now_iso()
+    dataset_chunks: dict[str, list[dict[str, Any]]] = {}
+    per_dataset_stats: dict[str, dict[str, float | int]] = {}
+
+    for dataset in selected:
+        dataset_id = str(dataset["dataset_id"])
+        files = dataset.get("files", [])
+        if not isinstance(files, list):
+            files = []
+
+        records: list[dict[str, Any]] = []
+        sequence = 1
+
+        for file_entry in files:
+            if not isinstance(file_entry, dict):
+                continue
+            source_relative_path = file_entry.get("relative_path")
+            if not isinstance(source_relative_path, str) or not source_relative_path.strip():
+                continue
+
+            raw_path = _resolve_manifest_entry_path(manifest_path, source_relative_path.strip())
+            selected_path = _find_redacted_file(raw_path, backend_root=backend_root)
+            if not selected_path.exists() or not selected_path.is_file():
+                raise FileNotFoundError(
+                    f"Dataset `{dataset_id}` source file missing: {source_relative_path}"
+                )
+            _ensure_supported(selected_path)
+
+            extracted = extract_units(selected_path)
+            spans = build_spans(
+                extracted.units,
+                max_chars=max_chars,
+                min_chars=min_chars,
+                overlap_chars=overlap_chars,
+            )
+
+            file_type = file_entry.get("file_type")
+            if not isinstance(file_type, str) or not file_type.strip():
+                file_type = selected_path.suffix.lower().lstrip(".")
+
+            sha256 = _sha256_file(selected_path)
+
+            for span in spans:
+                meta: dict[str, Any] = {
+                    "source_relative_path": source_relative_path,
+                    "file_type": file_type,
+                    "sha256": sha256,
+                    "dataset_id": dataset_id,
+                    "created_at": created_at,
+                    "char_count": len(span.text),
+                }
+                if extracted.locator_key == "page":
+                    meta["page_start"] = span.start
+                    meta["page_end"] = span.end
+                elif extracted.locator_key == "paragraph":
+                    meta["paragraph_start"] = span.start
+                    meta["paragraph_end"] = span.end
+                elif extracted.locator_key == "slide":
+                    meta["slide_start"] = span.start
+                    meta["slide_end"] = span.end
+
+                if span.title:
+                    meta["title"] = span.title
+                if span.heading:
+                    meta["heading"] = span.heading
+
+                records.append(
+                    {
+                        "chunk_id": f"ch-{dataset_id}-{sequence:06d}",
+                        "text": span.text,
+                        "meta": meta,
+                    }
+                )
+                sequence += 1
+
+        dataset_chunks[dataset_id] = records
+
+        lengths = [len(record["text"]) for record in records]
+        total_chars = sum(lengths)
+        chunk_count = len(records)
+        per_dataset_stats[dataset_id] = {
+            "chunk_count": chunk_count,
+            "total_chars": total_chars,
+            "avg_chars": round(total_chars / chunk_count, 2) if chunk_count else 0,
+            "min_chars": min(lengths) if lengths else 0,
+            "max_chars": max(lengths) if lengths else 0,
+        }
+
+    stats = {
+        "version": "v1",
+        "created_at": created_at,
+        "max_chars": max_chars,
+        "min_chars": min_chars,
+        "overlap_chars": overlap_chars,
+        "datasets": per_dataset_stats,
+        "totals": {
+            "dataset_count": len(dataset_chunks),
+            "chunk_count": sum(entry["chunk_count"] for entry in per_dataset_stats.values()),
+            "total_chars": sum(entry["total_chars"] for entry in per_dataset_stats.values()),
+        },
+    }
+    return dataset_chunks, stats
+
+
+def write_outputs(
+    *,
+    out_dir: Path,
+    dataset_chunks: dict[str, list[dict[str, Any]]],
+    stats: dict[str, Any],
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for dataset_id, records in dataset_chunks.items():
+        out_path = out_dir / f"{dataset_id}.chunks.v1.jsonl"
+        with out_path.open("w", encoding="utf-8") as file_obj:
+            for record in records:
+                file_obj.write(json.dumps(record, ensure_ascii=False))
+                file_obj.write("\n")
+
+    stats_path = out_dir / "chunk_stats.v1.json"
+    stats_path.write_text(
+        json.dumps(stats, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build T3 chunks from dataset manifest files.")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST_PATH,
+        help=f"Path to manifest.v1.yaml (default: {DEFAULT_MANIFEST_PATH})",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help=f"Output directory for chunk JSONL and stats (default: {DEFAULT_OUT_DIR})",
+    )
+    parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=1200,
+        help="Maximum characters per chunk (default: 1200)",
+    )
+    parser.add_argument(
+        "--min-chars",
+        type=int,
+        default=200,
+        help="Target minimum characters per chunk when mergeable (default: 200)",
+    )
+    parser.add_argument(
+        "--overlap-chars",
+        type=int,
+        default=0,
+        help="Optional overlap characters between adjacent chunks (default: 0)",
+    )
+    parser.add_argument(
+        "--dataset-id",
+        type=str,
+        default=None,
+        help="Optional dataset_id filter; when set only one dataset is processed.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build in-memory stats only, skip writing JSONL/stats files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        dataset_chunks, stats = build_dataset_chunks(
+            manifest_path=args.manifest,
+            max_chars=args.max_chars,
+            min_chars=args.min_chars,
+            overlap_chars=args.overlap_chars,
+            dataset_id_filter=args.dataset_id,
+        )
+    except Exception as exc:
+        print(f"build_chunks failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.dry_run:
+        print(json.dumps(stats, ensure_ascii=False, indent=2))
+    else:
+        try:
+            write_outputs(out_dir=args.out_dir, dataset_chunks=dataset_chunks, stats=stats)
+        except Exception as exc:
+            print(f"Failed to write chunk outputs: {exc}", file=sys.stderr)
+            return 1
+
+    total_chunks = stats["totals"]["chunk_count"]
+    dataset_count = stats["totals"]["dataset_count"]
+    out_dir = args.out_dir.resolve()
+    suffix = " (dry-run, files not written)" if args.dry_run else ""
+    print(f"Processed datasets={dataset_count}, total_chunks={total_chunks}, output={out_dir}{suffix}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_dataset_chunking.py
+++ b/backend/tests/test_dataset_chunking.py
@@ -1,0 +1,238 @@
+# backend/tests/test_dataset_chunking.py
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+from docx import Document
+from pptx import Presentation
+from pptx.util import Inches
+
+
+BASE = Path(__file__).resolve().parents[1]
+SCRIPT = BASE / "scripts" / "datasets" / "build_chunks.py"
+
+
+def _run_build_chunks(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=BASE, capture_output=True, text=True, check=False)
+
+
+def _build_docx(path: Path) -> None:
+    document = Document()
+    document.add_paragraph("Lecture 01", style="Heading 1")
+    for index in range(6):
+        document.add_paragraph(
+            f"Docx paragraph {index}. This is sample content for chunk testing with traceability."
+        )
+    document.save(path)
+
+
+def _build_pptx(path: Path) -> None:
+    presentation = Presentation()
+    blank_layout = (
+        presentation.slide_layouts[6]
+        if len(presentation.slide_layouts) > 6
+        else presentation.slide_layouts[-1]
+    )
+    for index in range(2):
+        slide = presentation.slides.add_slide(blank_layout)
+        textbox = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(8), Inches(1.5))
+        textbox.text_frame.text = (
+            f"Slide {index + 1} text. Chunk traceability should preserve slide boundaries."
+        )
+    presentation.save(path)
+
+
+def _write_manifest(manifest_path: Path, datasets: list[dict]) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        yaml.safe_dump({"version": "v1", "datasets": datasets}, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return [json.loads(line) for line in lines]
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_build_chunks_outputs_txt_docx_pptx_and_stats(tmp_path) -> None:
+    backend_root = tmp_path / "backend"
+    raw_dir = backend_root / "datasets_local" / "raw"
+    redacted_dir = backend_root / "datasets_local" / "redacted"
+    out_dir = backend_root / "datasets_local" / "exports" / "chunks"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    redacted_dir.mkdir(parents=True, exist_ok=True)
+
+    txt_raw_path = raw_dir / "notes.txt"
+    txt_raw_path.write_text("RAW SHOULD NOT BE USED", encoding="utf-8")
+    txt_redacted_path = redacted_dir / "notes.txt"
+    txt_redacted_path.write_text(
+        (
+            "REDACTED paragraph A. This paragraph is intentionally long for chunking behavior.\n\n"
+            "REDACTED paragraph B. This paragraph also has enough text to trigger merge behavior.\n\n"
+            "REDACTED paragraph C. Keep this paragraph for verifying max-chars constraints.\n\n"
+            "REDACTED paragraph D. Final paragraph for sequence and stats validation."
+        ),
+        encoding="utf-8",
+    )
+
+    docx_path = raw_dir / "lecture.docx"
+    pptx_path = raw_dir / "slides.pptx"
+    _build_docx(docx_path)
+    _build_pptx(pptx_path)
+
+    manifest_path = backend_root / "docs" / "ai" / "datasets" / "manifest.v1.yaml"
+    _write_manifest(
+        manifest_path,
+        datasets=[
+            {
+                "dataset_id": "ds-txt",
+                "allowed_use": "infer_only",
+                "license": {"type": "TBD", "evidence": ""},
+                "privacy": {"redaction_status": "pending"},
+                "files": [
+                    {
+                        "relative_path": "backend/datasets_local/raw/notes.txt",
+                        "file_type": "text",
+                        "sha256": "0" * 64,
+                        "size_bytes": txt_raw_path.stat().st_size,
+                    }
+                ],
+                "updated_at": "2026-02-22T00:00:00Z",
+            },
+            {
+                "dataset_id": "ds-docx",
+                "allowed_use": "infer_only",
+                "license": {"type": "TBD", "evidence": ""},
+                "privacy": {"redaction_status": "pending"},
+                "files": [
+                    {
+                        "relative_path": "backend/datasets_local/raw/lecture.docx",
+                        "file_type": "docx",
+                        "sha256": "0" * 64,
+                        "size_bytes": docx_path.stat().st_size,
+                    }
+                ],
+                "updated_at": "2026-02-22T00:00:00Z",
+            },
+            {
+                "dataset_id": "ds-pptx",
+                "allowed_use": "infer_only",
+                "license": {"type": "TBD", "evidence": ""},
+                "privacy": {"redaction_status": "pending"},
+                "files": [
+                    {
+                        "relative_path": "backend/datasets_local/raw/slides.pptx",
+                        "file_type": "pptx",
+                        "sha256": "0" * 64,
+                        "size_bytes": pptx_path.stat().st_size,
+                    }
+                ],
+                "updated_at": "2026-02-22T00:00:00Z",
+            },
+        ],
+    )
+
+    result = _run_build_chunks(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--manifest",
+            str(manifest_path),
+            "--out-dir",
+            str(out_dir),
+            "--max-chars",
+            "120",
+            "--min-chars",
+            "40",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+
+    txt_records = _read_jsonl(out_dir / "ds-txt.chunks.v1.jsonl")
+    assert txt_records
+    assert [record["chunk_id"] for record in txt_records] == [
+        f"ch-ds-txt-{index:06d}" for index in range(1, len(txt_records) + 1)
+    ]
+    assert all(len(record["text"]) <= 120 for record in txt_records)
+    assert all("paragraph_start" in record["meta"] for record in txt_records)
+    assert all("paragraph_end" in record["meta"] for record in txt_records)
+    assert all(record["meta"]["source_relative_path"] == "backend/datasets_local/raw/notes.txt" for record in txt_records)
+    assert all(record["meta"]["sha256"] == _sha256_file(txt_redacted_path) for record in txt_records)
+    assert any("REDACTED paragraph" in record["text"] for record in txt_records)
+    assert all("RAW SHOULD NOT BE USED" not in record["text"] for record in txt_records)
+
+    docx_records = _read_jsonl(out_dir / "ds-docx.chunks.v1.jsonl")
+    assert docx_records
+    assert all("paragraph_start" in record["meta"] for record in docx_records)
+    assert all("paragraph_end" in record["meta"] for record in docx_records)
+    assert min(record["meta"]["paragraph_start"] for record in docx_records) == 0
+    assert max(record["meta"]["paragraph_end"] for record in docx_records) >= 5
+
+    pptx_records = _read_jsonl(out_dir / "ds-pptx.chunks.v1.jsonl")
+    assert pptx_records
+    assert all("slide_start" in record["meta"] for record in pptx_records)
+    assert all("slide_end" in record["meta"] for record in pptx_records)
+    assert min(record["meta"]["slide_start"] for record in pptx_records) == 1
+    assert max(record["meta"]["slide_end"] for record in pptx_records) >= 2
+
+    stats_path = out_dir / "chunk_stats.v1.json"
+    stats = json.loads(stats_path.read_text(encoding="utf-8"))
+    assert "datasets" in stats
+    assert stats["datasets"]["ds-txt"]["chunk_count"] == len(txt_records)
+    assert stats["datasets"]["ds-docx"]["chunk_count"] == len(docx_records)
+    assert stats["datasets"]["ds-pptx"]["chunk_count"] == len(pptx_records)
+    assert stats["datasets"]["ds-txt"]["total_chars"] >= stats["datasets"]["ds-txt"]["chunk_count"]
+
+
+def test_build_chunks_dry_run_does_not_write_files(tmp_path) -> None:
+    backend_root = tmp_path / "backend"
+    raw_dir = backend_root / "datasets_local" / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    txt_path = raw_dir / "dry-run.txt"
+    txt_path.write_text("Dry run paragraph one.\n\nDry run paragraph two.", encoding="utf-8")
+
+    manifest_path = backend_root / "docs" / "ai" / "datasets" / "manifest.v1.yaml"
+    _write_manifest(
+        manifest_path,
+        datasets=[
+            {
+                "dataset_id": "ds-dry-run",
+                "allowed_use": "infer_only",
+                "license": {"type": "TBD", "evidence": ""},
+                "privacy": {"redaction_status": "pending"},
+                "files": [
+                    {
+                        "relative_path": "backend/datasets_local/raw/dry-run.txt",
+                        "file_type": "text",
+                        "sha256": "0" * 64,
+                        "size_bytes": txt_path.stat().st_size,
+                    }
+                ],
+                "updated_at": "2026-02-22T00:00:00Z",
+            }
+        ],
+    )
+
+    out_dir = backend_root / "datasets_local" / "exports" / "chunks"
+    result = _run_build_chunks(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--manifest",
+            str(manifest_path),
+            "--out-dir",
+            str(out_dir),
+            "--dry-run",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    assert not out_dir.exists()


### PR DESCRIPTION
### 變更摘要
完成 AI 流程 T3（Chunk -> Intermediate）工程化落地：新增 chunking CLI、輸出 JSONL/stats、schema 與規則文件、pytest 測試。支援 PDF/DOCX/PPTX/TXT/MD 抽字切塊，輸出具備 traceability 的中介 chunks（{dataset_id}.chunks.v1.jsonl）供後續 T4/T5 使用。

### 主要變更
- T3 Chunking CLI
  - 新增 `backend/scripts/datasets/build_chunks.py`
  - 讀取 `backend/docs/ai/datasets/manifest.v1.yaml` 的 datasets/files
  - redacted 優先選檔（不存在才用 raw）
  - 支援 pdf/docx/pptx/txt/md 抽字並以 unit（page/paragraph/slide）為邊界合併切塊
  - 輸出：
    - per-dataset JSONL：`backend/datasets_local/exports/chunks/{dataset_id}.chunks.v1.jsonl`
    - 統計：`backend/datasets_local/exports/chunks/chunk_stats.v1.json`
  - 支援 `--dataset-id`、`--dry-run`、`--max-chars/--min-chars/--overlap-chars`

- 輸出契約與規格文件
  - 新增 `backend/docs/ai/datasets/document_chunks.schema.v1.json`：定義 chunk record schema（chunk_id/text/meta + traceability 欄位）
  - 新增 `backend/docs/ai/datasets/chunking_rules.v1.md`：說明 I/O、chunking 規則、參數、stats 欄位與 CLI 用法

- 測試
  - 新增 `backend/tests/test_dataset_chunking.py`
  - 覆蓋 txt/docx/pptx 的抽字與 chunk/stats 正確性
  - 覆蓋 dry-run 不落檔行為

### 為什麼要改
T3 是後續訓練資料管線（清洗、標註、樣本組裝）的關鍵中介層：需要把不同格式文件抽成一致的 chunks，並保留可追溯的 locator 資訊，才能在後續 debug、回溯、或品質控管時精準定位來源。

### 如何驗證（本地測試）
在 repo root：
  python -m pytest -q
  python backend/scripts/datasets/build_chunks.py --dry-run
  python backend/scripts/datasets/build_chunks.py

或在 backend/：
  cd backend
  python -m pytest -q
  python scripts/datasets/build_chunks.py --dry-run
  python scripts/datasets/build_chunks.py

### 安全/合規確認
- 未提交任何真實教材檔案或 chunk 產物（datasets_local/exports 仍維持本機輸出）
- 未提交任何 secrets（.env、keys、token、連線字串等）

### 檢查清單
- [x] `datasets_local/` 僅保留 `.gitkeep`（無教材內容 / 無輸出產物被追蹤）
- [x] CLI 可成功產出 `{dataset_id}.chunks.v1.jsonl` 與 `chunk_stats.v1.json`
- [x] chunk schema 與規則文件齊全，meta traceability 欄位可回溯
- [x] `pytest` 全部通過（repo root 與 backend 內皆可重現）