### PR TITLE
feat(t4): build and validate instruction dataset jsonl

### DIFF
--- a/backend/docs/ai/datasets/instruction_dataset_v1/README.md
+++ b/backend/docs/ai/datasets/instruction_dataset_v1/README.md
@@ -1,0 +1,83 @@
+# Instruction Dataset v1 (T4)
+
+此文件定義 Studydy T4 產出的可訓練指令資料集（SFT）格式，以及對應的 build / validate 使用方式。
+
+## 輸入來源（來自 T3）
+- 優先輸入：`backend/datasets_local/exports/chunks/*.chunks.v1.jsonl`
+- 每筆 chunk 至少含：`chunk_id`, `text`, `meta`
+- `meta` 需可追溯來源定位（例如 `source_relative_path`, `dataset_id`, `page_*` / `paragraph_*` / `slide_*`, `title`, `heading`）
+
+## SFT JSONL 欄位（每行一筆 JSON）
+- `id`: instruction sample id（例：`ins-ch-...`）
+- `dataset_version`: 固定 `instruction_dataset.v1`
+- `split`: `train` / `valid` / `test`（由 `--split` + `--seed` 決定）
+- `chunk_id`: 對應 T3 chunk id
+- `source`: 追溯資訊
+- `meta`: 原始 chunk meta（保留定位與來源欄位）
+- `prompt` + `completion`（`prompt_completion` 格式）或 `messages`（`conversational` 格式）
+- `output_json`: 目標 Study Pack JSON object（需符合 `study_pack.schema.v1.json`）
+
+`source` 物件建議欄位：
+- `doc_id`
+- `dataset_id`
+- `chunk_id`
+- `source_relative_path`
+- `sha256`
+- `locator`（包含 page/paragraph/slide/title/heading 等）
+
+## 可選 DPO JSONL 欄位
+- `id`
+- `dataset_version`: 固定 `preference_dataset.v1`
+- `split`
+- `prompt`
+- `chosen`
+- `rejected`
+- `source`
+- `chunk_id`
+
+## Build 指令
+在 repo root 執行：
+
+```bash
+python backend/scripts/datasets/build_instruction_dataset.py \
+  --input backend/datasets_local/exports/chunks \
+  --input-format jsonl \
+  --out-dir backend/datasets_local/exports \
+  --study-pack-schema backend/docs/ai/study_pack_v1/study_pack.schema.v1.json \
+  --split train:0.9,valid:0.1 \
+  --seed 42 \
+  --max-context-chars 8000 \
+  --format prompt_completion
+```
+
+輸出檔案（依 split）：
+- `backend/datasets_local/exports/instruction_dataset.v1.train.jsonl`
+- `backend/datasets_local/exports/instruction_dataset.v1.valid.jsonl`
+- `backend/datasets_local/exports/instruction_dataset.build_report.v1.json`
+
+啟用 DPO 輸出：
+
+```bash
+python backend/scripts/datasets/build_instruction_dataset.py \
+  --input backend/datasets_local/exports/chunks \
+  --input-format jsonl \
+  --with-dpo
+```
+
+## Validate 指令
+在 repo root 執行：
+
+```bash
+python backend/scripts/datasets/validate_instruction_dataset.py \
+  --input backend/datasets_local/exports \
+  --study-pack-schema backend/docs/ai/study_pack_v1/study_pack.schema.v1.json
+```
+
+預設會輸出：
+- `backend/datasets_local/exports/instruction_dataset.validation_report.v1.json`
+- `backend/datasets_local/exports/instruction_dataset.quarantine.v1.jsonl`（invalid ids）
+
+## Gate 重點
+- 每筆資料必須可追溯到 `chunk_id` 與原始定位（`source/meta/locator`）。
+- 若含 `output_json`，必須可通過 Study Pack schema v1 驗證。
+- `datasets_local` 屬本機產物，禁止提交資料內容到 Git（僅保留 `.gitkeep`）。

--- a/backend/scripts/datasets/build_instruction_dataset.py
+++ b/backend/scripts/datasets/build_instruction_dataset.py
@@ -1,0 +1,558 @@
+"""Build T4 instruction dataset JSONL files from T3 chunk JSONL outputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INPUT_PATH = BACKEND_ROOT / "datasets_local" / "exports" / "chunks"
+DEFAULT_OUT_DIR = BACKEND_ROOT / "datasets_local" / "exports"
+DEFAULT_STUDY_PACK_SCHEMA = (
+    BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "study_pack.schema.v1.json"
+)
+DATASET_VERSION = "instruction_dataset.v1"
+PREFERENCE_DATASET_VERSION = "preference_dataset.v1"
+
+PROMPT_COMPLETION = "prompt_completion"
+CONVERSATIONAL = "conversational"
+FORMAT_CHOICES = (PROMPT_COMPLETION, CONVERSATIONAL)
+
+LOCATOR_KEYS = (
+    "page_start",
+    "page_end",
+    "paragraph_start",
+    "paragraph_end",
+    "slide_start",
+    "slide_end",
+    "title",
+    "heading",
+)
+
+
+@dataclass(slots=True)
+class BuildResult:
+    sft_records: list[dict[str, Any]]
+    dpo_records: list[dict[str, Any]]
+    split_counts: dict[str, int]
+    input_count: int
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_split_spec(split_spec: str) -> list[tuple[str, float]]:
+    chunks = [part.strip() for part in split_spec.split(",") if part.strip()]
+    if not chunks:
+        raise ValueError("split spec is empty; expected format like train:0.9,valid:0.1")
+
+    parsed: list[tuple[str, float]] = []
+    total = 0.0
+    for chunk in chunks:
+        if ":" not in chunk:
+            raise ValueError(f"invalid split spec chunk: {chunk}")
+        split_name, ratio_text = chunk.split(":", 1)
+        split_name = split_name.strip()
+        if not split_name:
+            raise ValueError(f"split name cannot be empty: {chunk}")
+        try:
+            ratio = float(ratio_text.strip())
+        except ValueError as exc:
+            raise ValueError(f"split ratio must be numeric: {chunk}") from exc
+        if ratio <= 0:
+            raise ValueError(f"split ratio must be > 0: {chunk}")
+        parsed.append((split_name, ratio))
+        total += ratio
+
+    if total <= 0:
+        raise ValueError("split ratios sum to zero")
+
+    return [(split_name, ratio / total) for split_name, ratio in parsed]
+
+
+def assign_split(record_id: str, splits: list[tuple[str, float]], seed: int) -> str:
+    digest = hashlib.sha256(f"{seed}:{record_id}".encode("utf-8")).digest()
+    sample = int.from_bytes(digest[:8], byteorder="big", signed=False) / float(1 << 64)
+
+    threshold = 0.0
+    for split_name, ratio in splits:
+        threshold += ratio
+        if sample < threshold:
+            return split_name
+    return splits[-1][0]
+
+
+def discover_chunk_files(input_path: Path) -> list[Path]:
+    if input_path.is_file():
+        return [input_path.resolve()]
+    if not input_path.exists():
+        raise FileNotFoundError(f"input path does not exist: {input_path}")
+    if not input_path.is_dir():
+        raise ValueError(f"input path must be file or directory: {input_path}")
+
+    preferred = sorted(path.resolve() for path in input_path.rglob("*.chunks.v1.jsonl"))
+    if preferred:
+        return preferred
+
+    fallback = sorted(path.resolve() for path in input_path.rglob("*.jsonl"))
+    if fallback:
+        return fallback
+    raise ValueError(f"no JSONL files found under: {input_path}")
+
+
+def _normalize_chunk_record(
+    raw_record: dict[str, Any], *, source_file: Path, line_number: int
+) -> dict[str, Any]:
+    chunk_id = raw_record.get("chunk_id")
+    if not isinstance(chunk_id, str) or not chunk_id.strip():
+        raise ValueError(f"{source_file}:{line_number} missing valid chunk_id")
+
+    text = raw_record.get("text")
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError(f"{source_file}:{line_number} missing valid text")
+
+    meta = raw_record.get("meta")
+    if not isinstance(meta, dict):
+        raise ValueError(f"{source_file}:{line_number} missing valid meta object")
+
+    return {"chunk_id": chunk_id.strip(), "text": text, "meta": meta}
+
+
+def load_chunks_from_jsonl(input_path: Path) -> tuple[list[dict[str, Any]], list[Path]]:
+    files = discover_chunk_files(input_path)
+    records: list[dict[str, Any]] = []
+    for file_path in files:
+        with file_path.open("r", encoding="utf-8") as file_obj:
+            for line_number, line in enumerate(file_obj, start=1):
+                payload = line.strip()
+                if not payload:
+                    continue
+                try:
+                    raw_record = json.loads(payload)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(f"invalid JSON at {file_path}:{line_number}: {exc}") from exc
+                if not isinstance(raw_record, dict):
+                    raise ValueError(f"{file_path}:{line_number} must be a JSON object")
+                records.append(
+                    _normalize_chunk_record(
+                        raw_record,
+                        source_file=file_path,
+                        line_number=line_number,
+                    )
+                )
+    if not records:
+        raise ValueError(f"no chunk records loaded from {input_path}")
+    return records, files
+
+
+def load_chunks_from_db(_input_value: str) -> tuple[list[dict[str, Any]], list[Path]]:
+    raise NotImplementedError(
+        "input-format=db is not implemented yet. "
+        "Please export chunk JSONL first and use --input-format jsonl."
+    )
+
+
+def trim_context(text: str, max_context_chars: int) -> str:
+    if max_context_chars <= 0:
+        raise ValueError("max_context_chars must be > 0")
+    content = text.strip()
+    if len(content) <= max_context_chars:
+        return content
+    return content[:max_context_chars].rstrip()
+
+
+def _compact_text(text: str) -> str:
+    return " ".join(part for part in text.split())
+
+
+def _short_key_point(text: str, max_chars: int = 280) -> str:
+    compact = _compact_text(text)
+    if not compact:
+        return "重點整理"
+    if len(compact) <= max_chars:
+        return compact
+    cropped = compact[:max_chars].rstrip()
+    boundary = cropped.rfind(" ")
+    if boundary >= max_chars // 3:
+        cropped = cropped[:boundary].rstrip()
+    return cropped or compact[:max_chars]
+
+
+def build_study_pack_output(context: str) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "language": "zh-TW",
+        "outline": [],
+        "key_points": [_short_key_point(context)],
+        "glossary": [],
+        "quiz": [],
+        "story_nodes": [],
+    }
+
+
+def build_locator(meta: dict[str, Any]) -> dict[str, Any]:
+    locator: dict[str, Any] = {}
+    for key in LOCATOR_KEYS:
+        if key in meta:
+            locator[key] = meta[key]
+
+    nested_locator = meta.get("locator")
+    if isinstance(nested_locator, dict):
+        for key, value in nested_locator.items():
+            locator.setdefault(key, value)
+    return locator
+
+
+def infer_doc_id(meta: dict[str, Any]) -> str:
+    existing = meta.get("doc_id")
+    if isinstance(existing, str) and existing.strip():
+        return existing.strip()
+
+    source_relative_path = str(meta.get("source_relative_path", "")).strip()
+    sha256 = str(meta.get("sha256", "")).strip()
+    dataset_id = str(meta.get("dataset_id", "")).strip()
+    basis = "|".join([source_relative_path, sha256, dataset_id])
+    digest = hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+    return f"doc-{digest}"
+
+
+def build_prompts(
+    *,
+    chunk_id: str,
+    source_relative_path: str,
+    locator: dict[str, Any],
+    context: str,
+    schema_path: Path,
+) -> tuple[str, str]:
+    system_prompt = (
+        "You are a Studydy dataset annotation assistant. "
+        "Return exactly one JSON object that must satisfy Study Pack schema v1. "
+        "Do not output markdown, code fences, or extra commentary. "
+        f"Schema reference: {schema_path}."
+    )
+    user_prompt = (
+        f"chunk_id: {chunk_id}\n"
+        f"source_relative_path: {source_relative_path}\n"
+        f"locator: {json.dumps(locator, ensure_ascii=False, sort_keys=True)}\n\n"
+        "Generate a Study Pack JSON object from the following context:\n"
+        f"{context}"
+    )
+    return system_prompt, user_prompt
+
+
+def _build_prompt_text(system_prompt: str, user_prompt: str) -> str:
+    return f"[SYSTEM]\n{system_prompt}\n\n[USER]\n{user_prompt}"
+
+
+def build_sft_record(
+    chunk: dict[str, Any],
+    *,
+    split: str,
+    format_name: str,
+    max_context_chars: int,
+    schema_path: Path,
+) -> dict[str, Any]:
+    chunk_id = str(chunk["chunk_id"])
+    meta = dict(chunk["meta"])
+    context = trim_context(str(chunk["text"]), max_context_chars=max_context_chars)
+    locator = build_locator(meta)
+    source_relative_path = str(meta.get("source_relative_path", ""))
+
+    source = {
+        "doc_id": infer_doc_id(meta),
+        "dataset_id": meta.get("dataset_id"),
+        "chunk_id": chunk_id,
+        "source_relative_path": source_relative_path,
+        "sha256": meta.get("sha256"),
+        "locator": locator,
+    }
+    output_json = build_study_pack_output(context)
+    system_prompt, user_prompt = build_prompts(
+        chunk_id=chunk_id,
+        source_relative_path=source_relative_path,
+        locator=locator,
+        context=context,
+        schema_path=schema_path,
+    )
+
+    record: dict[str, Any] = {
+        "id": f"ins-{chunk_id}",
+        "dataset_version": DATASET_VERSION,
+        "split": split,
+        "chunk_id": chunk_id,
+        "source": source,
+        "meta": meta,
+        "output_json": output_json,
+    }
+
+    if format_name == PROMPT_COMPLETION:
+        record["prompt"] = _build_prompt_text(system_prompt, user_prompt)
+        record["completion"] = json.dumps(output_json, ensure_ascii=False)
+    else:
+        record["messages"] = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+    return record
+
+
+def build_dpo_record(sft_record: dict[str, Any]) -> dict[str, Any]:
+    prompt = sft_record.get("prompt")
+    if not isinstance(prompt, str):
+        messages = sft_record.get("messages", [])
+        prompt = json.dumps(messages, ensure_ascii=False)
+
+    chosen_json = json.dumps(sft_record["output_json"], ensure_ascii=False)
+    rejected_json = json.dumps({"schema_version": "1.0", "outline": []}, ensure_ascii=False)
+    return {
+        "id": f"dpo-{sft_record['chunk_id']}",
+        "dataset_version": PREFERENCE_DATASET_VERSION,
+        "split": sft_record["split"],
+        "prompt": prompt,
+        "chosen": chosen_json,
+        "rejected": rejected_json,
+        "source": sft_record["source"],
+        "chunk_id": sft_record["chunk_id"],
+    }
+
+
+def build_instruction_records(
+    *,
+    chunks: list[dict[str, Any]],
+    split_spec: str,
+    seed: int,
+    max_context_chars: int,
+    format_name: str,
+    schema_path: Path,
+    with_dpo: bool,
+) -> BuildResult:
+    if format_name not in FORMAT_CHOICES:
+        raise ValueError(f"unsupported format: {format_name}")
+
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft202012Validator(schema)
+    split_definitions = parse_split_spec(split_spec)
+
+    sft_records: list[dict[str, Any]] = []
+    dpo_records: list[dict[str, Any]] = []
+    split_counts: dict[str, int] = {}
+
+    for chunk in sorted(chunks, key=lambda item: str(item["chunk_id"])):
+        record_id = f"ins-{chunk['chunk_id']}"
+        split = assign_split(record_id=record_id, splits=split_definitions, seed=seed)
+        sft_record = build_sft_record(
+            chunk,
+            split=split,
+            format_name=format_name,
+            max_context_chars=max_context_chars,
+            schema_path=schema_path,
+        )
+
+        try:
+            validator.validate(sft_record["output_json"])
+        except jsonschema.ValidationError as exc:
+            raise ValueError(f"{chunk['chunk_id']} generated invalid output_json: {exc.message}") from exc
+
+        sft_records.append(sft_record)
+        split_counts[split] = split_counts.get(split, 0) + 1
+        if with_dpo:
+            dpo_records.append(build_dpo_record(sft_record))
+
+    return BuildResult(
+        sft_records=sft_records,
+        dpo_records=dpo_records,
+        split_counts=split_counts,
+        input_count=len(chunks),
+    )
+
+
+def _write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as file_obj:
+        for record in records:
+            file_obj.write(json.dumps(record, ensure_ascii=False))
+            file_obj.write("\n")
+
+
+def write_split_jsonl(
+    *,
+    out_dir: Path,
+    records: list[dict[str, Any]],
+    dataset_version: str,
+) -> list[Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        split = str(record["split"])
+        grouped.setdefault(split, []).append(record)
+
+    for split_name in sorted(grouped):
+        items = sorted(grouped[split_name], key=lambda item: str(item["id"]))
+        output_path = out_dir / f"{dataset_version}.{split_name}.jsonl"
+        _write_jsonl(output_path, items)
+        paths.append(output_path)
+
+    return paths
+
+
+def write_build_report(
+    *,
+    out_dir: Path,
+    args: argparse.Namespace,
+    result: BuildResult,
+    written_files: list[Path],
+    input_files: list[Path],
+) -> Path:
+    payload = {
+        "version": "v1",
+        "built_at": utc_now_iso(),
+        "config": {
+            "input": args.input,
+            "input_format": args.input_format,
+            "study_pack_schema": str(args.study_pack_schema),
+            "split": args.split,
+            "seed": args.seed,
+            "max_context_chars": args.max_context_chars,
+            "format": args.format,
+            "with_dpo": args.with_dpo,
+            "out_dir": str(args.out_dir),
+        },
+        "input_files": [str(path) for path in input_files],
+        "input_records": result.input_count,
+        "sft_records": len(result.sft_records),
+        "dpo_records": len(result.dpo_records),
+        "split_counts": result.split_counts,
+        "output_files": [str(path) for path in written_files],
+    }
+    report_path = out_dir / "instruction_dataset.build_report.v1.json"
+    report_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return report_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build T4 instruction dataset from T3 chunks.")
+    parser.add_argument(
+        "--input",
+        type=str,
+        default=str(DEFAULT_INPUT_PATH),
+        help=f"Chunk input path (file or dir) or db DSN (default: {DEFAULT_INPUT_PATH})",
+    )
+    parser.add_argument(
+        "--input-format",
+        type=str,
+        choices=("jsonl", "db"),
+        default="jsonl",
+        help="Input type for chunk records (default: jsonl)",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help=f"Output directory for instruction dataset JSONL files (default: {DEFAULT_OUT_DIR})",
+    )
+    parser.add_argument(
+        "--study-pack-schema",
+        type=Path,
+        default=DEFAULT_STUDY_PACK_SCHEMA,
+        help=f"Study Pack schema path (default: {DEFAULT_STUDY_PACK_SCHEMA})",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="train:0.9,valid:0.1",
+        help="Split ratios, e.g. train:0.9,valid:0.1",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Deterministic seed for split assignment (default: 42)",
+    )
+    parser.add_argument(
+        "--max-context-chars",
+        type=int,
+        default=8000,
+        help="Max chars kept in prompt context per sample (default: 8000)",
+    )
+    parser.add_argument(
+        "--format",
+        type=str,
+        choices=FORMAT_CHOICES,
+        default=PROMPT_COMPLETION,
+        help=f"SFT format (default: {PROMPT_COMPLETION})",
+    )
+    parser.add_argument(
+        "--with-dpo",
+        action="store_true",
+        help="Also write preference dataset JSONL files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.input_format == "jsonl":
+            chunks, input_files = load_chunks_from_jsonl(Path(args.input))
+        else:
+            chunks, input_files = load_chunks_from_db(args.input)
+
+        result = build_instruction_records(
+            chunks=chunks,
+            split_spec=args.split,
+            seed=args.seed,
+            max_context_chars=args.max_context_chars,
+            format_name=args.format,
+            schema_path=args.study_pack_schema,
+            with_dpo=args.with_dpo,
+        )
+
+        written_files = write_split_jsonl(
+            out_dir=args.out_dir,
+            records=result.sft_records,
+            dataset_version=DATASET_VERSION,
+        )
+        if args.with_dpo:
+            written_files.extend(
+                write_split_jsonl(
+                    out_dir=args.out_dir,
+                    records=result.dpo_records,
+                    dataset_version=PREFERENCE_DATASET_VERSION,
+                )
+            )
+
+        report_path = write_build_report(
+            out_dir=args.out_dir,
+            args=args,
+            result=result,
+            written_files=written_files,
+            input_files=input_files,
+        )
+    except Exception as exc:
+        print(f"build_instruction_dataset failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        "Built instruction dataset: "
+        f"input_records={result.input_count}, "
+        f"sft_records={len(result.sft_records)}, "
+        f"dpo_records={len(result.dpo_records)}, "
+        f"out_dir={args.out_dir.resolve()}, "
+        f"report={report_path.resolve()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/datasets/validate_instruction_dataset.py
+++ b/backend/scripts/datasets/validate_instruction_dataset.py
@@ -1,0 +1,255 @@
+"""Validate T4 instruction dataset JSONL against required fields and Study Pack schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA_PATH = (
+    BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "study_pack.schema.v1.json"
+)
+DEFAULT_INPUT_PATH = BACKEND_ROOT / "datasets_local" / "exports"
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_dataset_files(input_path: Path) -> list[Path]:
+    if input_path.is_file():
+        return [input_path.resolve()]
+    if not input_path.exists():
+        raise FileNotFoundError(f"input path does not exist: {input_path}")
+    if not input_path.is_dir():
+        raise ValueError(f"input path must be file or directory: {input_path}")
+
+    preferred = sorted(path.resolve() for path in input_path.glob("instruction_dataset.v1.*.jsonl"))
+    if preferred:
+        return preferred
+
+    fallback = sorted(path.resolve() for path in input_path.rglob("*.jsonl"))
+    if fallback:
+        return fallback
+    raise ValueError(f"no JSONL files found under: {input_path}")
+
+
+def validate_source(source: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(source, dict):
+        return ["source must be an object"]
+    for key in ("doc_id", "chunk_id", "locator"):
+        if key not in source:
+            errors.append(f"source missing required field: {key}")
+    return errors
+
+
+def validate_messages(messages: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(messages, list) or not messages:
+        return ["messages must be a non-empty array"]
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            errors.append(f"messages[{index}] must be an object")
+            continue
+        if "role" not in message:
+            errors.append(f"messages[{index}] missing role")
+        if "content" not in message:
+            errors.append(f"messages[{index}] missing content")
+    return errors
+
+
+def validate_record_shape(record: Any) -> list[str]:
+    if not isinstance(record, dict):
+        return ["record must be a JSON object"]
+
+    errors: list[str] = []
+    for field in ("id", "dataset_version", "split", "source", "chunk_id", "meta"):
+        if field not in record:
+            errors.append(f"missing required field: {field}")
+
+    if "source" in record:
+        errors.extend(validate_source(record["source"]))
+        source = record.get("source")
+        if isinstance(source, dict) and source.get("chunk_id") != record.get("chunk_id"):
+            errors.append("source.chunk_id must equal chunk_id")
+
+    if "meta" in record and not isinstance(record.get("meta"), dict):
+        errors.append("meta must be an object")
+
+    has_prompt_completion = isinstance(record.get("prompt"), str) and isinstance(
+        record.get("completion"), str
+    )
+    has_messages = "messages" in record
+
+    if not has_prompt_completion and not has_messages:
+        errors.append("record must contain prompt+completion or messages")
+    if has_messages:
+        errors.extend(validate_messages(record.get("messages")))
+
+    if "output_json" not in record:
+        errors.append("missing required field: output_json")
+    elif not isinstance(record.get("output_json"), dict):
+        errors.append("output_json must be an object")
+
+    return errors
+
+
+def validate_instruction_dataset(
+    *,
+    input_path: Path,
+    schema_path: Path,
+    report_path: Path | None = None,
+    quarantine_path: Path | None = None,
+) -> dict[str, Any]:
+    files = discover_dataset_files(input_path)
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft202012Validator(schema)
+
+    issues: list[dict[str, Any]] = []
+    total_records = 0
+
+    for file_path in files:
+        with file_path.open("r", encoding="utf-8") as file_obj:
+            for line_number, line in enumerate(file_obj, start=1):
+                payload = line.strip()
+                if not payload:
+                    continue
+                total_records += 1
+
+                record: Any
+                parse_errors: list[str] = []
+                try:
+                    record = json.loads(payload)
+                except json.JSONDecodeError as exc:
+                    record = {}
+                    parse_errors.append(f"invalid JSON: {exc}")
+
+                record_id = (
+                    str(record.get("id")).strip()
+                    if isinstance(record, dict) and isinstance(record.get("id"), str)
+                    else f"{file_path.name}:{line_number}"
+                )
+                errors = parse_errors + validate_record_shape(record)
+
+                output_json = record.get("output_json") if isinstance(record, dict) else None
+                if isinstance(output_json, dict):
+                    schema_errors = sorted(
+                        validator.iter_errors(output_json), key=lambda item: list(item.path)
+                    )
+                    for error in schema_errors:
+                        path = ".".join(str(part) for part in error.path) or "<root>"
+                        errors.append(f"output_json schema violation at {path}: {error.message}")
+
+                if errors:
+                    issues.append(
+                        {
+                            "id": record_id,
+                            "file": str(file_path),
+                            "line": line_number,
+                            "errors": errors,
+                        }
+                    )
+
+    invalid_records = len(issues)
+    valid_records = total_records - invalid_records
+    invalid_ids = [issue["id"] for issue in issues]
+
+    report = {
+        "version": "v1",
+        "validated_at": utc_now_iso(),
+        "input_path": str(input_path),
+        "schema_path": str(schema_path),
+        "files": [str(path) for path in files],
+        "total_records": total_records,
+        "valid_records": valid_records,
+        "invalid_records": invalid_records,
+        "invalid_ids": invalid_ids,
+        "issues": issues,
+    }
+
+    base_dir = input_path if input_path.is_dir() else input_path.parent
+    if report_path is None:
+        report_path = base_dir / "instruction_dataset.validation_report.v1.json"
+    if quarantine_path is None:
+        quarantine_path = base_dir / "instruction_dataset.quarantine.v1.jsonl"
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    quarantine_path.parent.mkdir(parents=True, exist_ok=True)
+    with quarantine_path.open("w", encoding="utf-8") as file_obj:
+        for issue in issues:
+            file_obj.write(
+                json.dumps(
+                    {"id": issue["id"], "file": issue["file"], "line": issue["line"]},
+                    ensure_ascii=False,
+                )
+            )
+            file_obj.write("\n")
+
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate T4 instruction dataset JSONL files.")
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=DEFAULT_INPUT_PATH,
+        help=f"Instruction dataset file or directory (default: {DEFAULT_INPUT_PATH})",
+    )
+    parser.add_argument(
+        "--study-pack-schema",
+        type=Path,
+        default=DEFAULT_SCHEMA_PATH,
+        help=f"Study Pack schema path (default: {DEFAULT_SCHEMA_PATH})",
+    )
+    parser.add_argument(
+        "--report-path",
+        type=Path,
+        default=None,
+        help="Optional path for validation report JSON.",
+    )
+    parser.add_argument(
+        "--quarantine-path",
+        type=Path,
+        default=None,
+        help="Optional path for quarantine JSONL (invalid ids).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = validate_instruction_dataset(
+            input_path=args.input,
+            schema_path=args.study_pack_schema,
+            report_path=args.report_path,
+            quarantine_path=args.quarantine_path,
+        )
+    except Exception as exc:
+        print(f"validate_instruction_dataset failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        "Validation summary: "
+        f"total={report['total_records']}, "
+        f"valid={report['valid_records']}, "
+        f"invalid={report['invalid_records']}"
+    )
+    if report["invalid_records"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/scripts/test_build_instruction_dataset.py
+++ b/backend/tests/scripts/test_build_instruction_dataset.py
@@ -1,0 +1,116 @@
+import json
+from pathlib import Path
+
+from scripts.datasets.build_instruction_dataset import (
+    DATASET_VERSION,
+    build_instruction_records,
+    load_chunks_from_jsonl,
+    write_split_jsonl,
+)
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "study_pack.schema.v1.json"
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as file_obj:
+        for record in records:
+            file_obj.write(json.dumps(record, ensure_ascii=False))
+            file_obj.write("\n")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with path.open("r", encoding="utf-8") as file_obj:
+        for line in file_obj:
+            payload = line.strip()
+            if payload:
+                rows.append(json.loads(payload))
+    return rows
+
+
+def _chunk(chunk_id: str, text: str, paragraph_start: int) -> dict:
+    return {
+        "chunk_id": chunk_id,
+        "text": text,
+        "meta": {
+            "dataset_id": "ds-fixture",
+            "source_relative_path": "backend/datasets_local/raw/fixture.txt",
+            "sha256": "a" * 64,
+            "created_at": "2026-02-25T00:00:00Z",
+            "char_count": len(text),
+            "paragraph_start": paragraph_start,
+            "paragraph_end": paragraph_start,
+            "title": "Fixture",
+        },
+    }
+
+
+def test_build_instruction_dataset_from_jsonl_minimal(tmp_path) -> None:
+    input_path = tmp_path / "fixture.chunks.v1.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            _chunk("ch-ds-fixture-000001", "第一段內容，這是測試資料。", 0),
+            _chunk("ch-ds-fixture-000002", "第二段內容，含有額外描述。", 1),
+            _chunk("ch-ds-fixture-000003", "第三段內容，用來檢查 split。", 2),
+        ],
+    )
+
+    chunks, input_files = load_chunks_from_jsonl(input_path)
+    assert input_files == [input_path.resolve()]
+
+    result = build_instruction_records(
+        chunks=chunks,
+        split_spec="train:0.67,valid:0.33",
+        seed=42,
+        max_context_chars=8000,
+        format_name="prompt_completion",
+        schema_path=SCHEMA_PATH,
+        with_dpo=False,
+    )
+
+    out_dir = tmp_path / "exports"
+    output_paths = write_split_jsonl(
+        out_dir=out_dir,
+        records=result.sft_records,
+        dataset_version=DATASET_VERSION,
+    )
+
+    built_records: list[dict] = []
+    for output_path in output_paths:
+        built_records.extend(_read_jsonl(output_path))
+
+    assert len(built_records) == 3
+    assert set(record["split"] for record in built_records).issubset({"train", "valid"})
+
+    required_fields = {
+        "id",
+        "dataset_version",
+        "split",
+        "source",
+        "chunk_id",
+        "meta",
+        "prompt",
+        "completion",
+        "output_json",
+    }
+    for record in built_records:
+        assert required_fields.issubset(set(record))
+        assert record["source"]["chunk_id"] == record["chunk_id"]
+        assert isinstance(record["source"]["locator"], dict)
+        assert record["dataset_version"] == DATASET_VERSION
+
+    same_seed_result = build_instruction_records(
+        chunks=chunks,
+        split_spec="train:0.67,valid:0.33",
+        seed=42,
+        max_context_chars=8000,
+        format_name="prompt_completion",
+        schema_path=SCHEMA_PATH,
+        with_dpo=False,
+    )
+    assert [(item["id"], item["split"]) for item in result.sft_records] == [
+        (item["id"], item["split"]) for item in same_seed_result.sft_records
+    ]

--- a/backend/tests/scripts/test_validate_instruction_dataset.py
+++ b/backend/tests/scripts/test_validate_instruction_dataset.py
@@ -1,0 +1,94 @@
+import json
+from pathlib import Path
+
+from scripts.datasets.validate_instruction_dataset import validate_instruction_dataset
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "study_pack.schema.v1.json"
+MINIMAL_VALID_PATH = (
+    BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "golden_samples" / "minimal_valid.json"
+)
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as file_obj:
+        for row in rows:
+            file_obj.write(json.dumps(row, ensure_ascii=False))
+            file_obj.write("\n")
+
+
+def _build_record(sample_id: str, output_json: dict) -> dict:
+    return {
+        "id": sample_id,
+        "dataset_version": "instruction_dataset.v1",
+        "split": "train",
+        "chunk_id": "ch-ds-fixture-000001",
+        "source": {
+            "doc_id": "doc-fixture-001",
+            "dataset_id": "ds-fixture",
+            "chunk_id": "ch-ds-fixture-000001",
+            "source_relative_path": "backend/datasets_local/raw/fixture.txt",
+            "sha256": "a" * 64,
+            "locator": {"paragraph_start": 0, "paragraph_end": 0},
+        },
+        "meta": {
+            "dataset_id": "ds-fixture",
+            "source_relative_path": "backend/datasets_local/raw/fixture.txt",
+            "sha256": "a" * 64,
+            "created_at": "2026-02-25T00:00:00Z",
+            "char_count": 20,
+            "paragraph_start": 0,
+            "paragraph_end": 0,
+        },
+        "prompt": "prompt",
+        "completion": json.dumps(output_json, ensure_ascii=False),
+        "output_json": output_json,
+    }
+
+
+def test_validate_instruction_dataset_schema_ok(tmp_path) -> None:
+    output_json = json.loads(MINIMAL_VALID_PATH.read_text(encoding="utf-8"))
+    dataset_path = tmp_path / "instruction_dataset.v1.train.jsonl"
+    _write_jsonl(dataset_path, [_build_record("ins-ok-001", output_json)])
+
+    report = validate_instruction_dataset(
+        input_path=dataset_path,
+        schema_path=SCHEMA_PATH,
+    )
+
+    assert report["total_records"] == 1
+    assert report["valid_records"] == 1
+    assert report["invalid_records"] == 0
+    assert report["invalid_ids"] == []
+
+
+def test_validate_instruction_dataset_schema_fail_quarantine(tmp_path) -> None:
+    invalid_output_json = {"schema_version": "1.0", "outline": []}
+    dataset_path = tmp_path / "instruction_dataset.v1.train.jsonl"
+    quarantine_path = tmp_path / "quarantine.jsonl"
+    _write_jsonl(dataset_path, [_build_record("ins-bad-001", invalid_output_json)])
+
+    report = validate_instruction_dataset(
+        input_path=dataset_path,
+        schema_path=SCHEMA_PATH,
+        quarantine_path=quarantine_path,
+    )
+
+    assert report["total_records"] == 1
+    assert report["valid_records"] == 0
+    assert report["invalid_records"] == 1
+    assert "ins-bad-001" in report["invalid_ids"]
+
+    quarantine_rows = [
+        json.loads(line)
+        for line in quarantine_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert quarantine_rows == [
+        {
+            "id": "ins-bad-001",
+            "file": str(dataset_path.resolve()),
+            "line": 1,
+        }
+    ]


### PR DESCRIPTION

### 變更摘要
完成 AI 流程 T4（Instruction Dataset Build）工程化落地：將 T3 chunks JSONL 轉換為可訓練的指令資料集（SFT JSONL），並提供對應的 validate 工具（含 validation report + quarantine）。支援可追溯來源（chunk_id + source/meta/locator），並可選輸出 DPO preference dataset。

### 主要變更
- T4 build script
  - 新增 `backend/scripts/datasets/build_instruction_dataset.py`
  - 以 T3 chunks JSONL 為主輸入（file/dir），輸出 `instruction_dataset.v1.<split>.jsonl`
  - 每筆包含 `chunk_id` + `source/meta/locator` 追溯欄位
  - 目標 `output_json` 以 Study Pack schema v1 為結構，build 階段即做 schema 驗證
  - 可選 `--with-dpo` 輸出 `preference_dataset.v1.<split>.jsonl`

- T4 validate script
  - 新增 `backend/scripts/datasets/validate_instruction_dataset.py`
  - 驗證必填欄位與資料形狀（prompt+completion / messages 二擇一）
  - 以 Study Pack schema v1 驗證 `output_json`
  - 產出 `instruction_dataset.validation_report.v1.json` + `instruction_dataset.quarantine.v1.jsonl`

- 文件
  - 新增 `backend/docs/ai/datasets/instruction_dataset_v1/README.md`
  - 定義 SFT/DPO 欄位、輸入來源與 build/validate 指令

- 測試
  - 新增 `backend/tests/scripts/test_build_instruction_dataset.py`
  - 新增 `backend/tests/scripts/test_validate_instruction_dataset.py`

### 為什麼要改
- T4 是後續資料清洗、訓練與驗證（T5+）的關鍵中介層：需要可重現、可追溯、可驗證的指令資料集輸出。
- 提前在 build/validate 階段做 schema gate，可降低後續訓練時才暴露資料問題的成本。

### 如何驗證（本地測試）
在 repo root：

1) Build（SFT）
```bash
python backend/scripts/datasets/build_instruction_dataset.py \
  --input backend/datasets_local/exports/chunks \
  --input-format jsonl \
  --out-dir backend/datasets_local/exports \
  --study-pack-schema backend/docs/ai/study_pack_v1/study_pack.schema.v1.json \
  --split train:0.9,valid:0.1 \
  --seed 42 \
  --max-context-chars 8000 \
  --format prompt_completion
````

2. Build（可選 DPO）

```bash
python backend/scripts/datasets/build_instruction_dataset.py \
  --input backend/datasets_local/exports/chunks \
  --input-format jsonl \
  --with-dpo
```

3. Validate

```bash
python backend/scripts/datasets/validate_instruction_dataset.py \
  --input backend/datasets_local/exports \
  --study-pack-schema backend/docs/ai/study_pack_v1/study_pack.schema.v1.json
```

4. Pytest

```bash
PYTHONPATH=backend pytest -q
# 或
PYTHONPATH=backend pytest -q backend/tests/scripts --confcutdir=backend/tests/scripts
```

### 安全/合規確認

* 未提交任何 `datasets_local/` 產物（僅保留目錄骨架必要檔案）
* 未提交任何 secrets（.env、keys、token、連線字串等）

### 檢查清單

* [x] `datasets_local/` 沒有被追蹤任何產物檔
* [x] build 可產出 `instruction_dataset.v1.*.jsonl` 與 build report
* [x] validate 會產出 validation report + quarantine（invalid ids）
* [x] `pytest` 全部通過（可重現）
