### PR TITLE
feat(t5): add schema gate for training data (study pack)

### DIFF
--- a/backend/docs/ai/study_pack_v1/README.md
+++ b/backend/docs/ai/study_pack_v1/README.md
@@ -18,3 +18,14 @@
 - 使用 `python-jsonschema` 的 `Draft202012Validator` 驗證 schema 與 instance。
 - 使用 `pytest` 驗證固定 golden samples（`minimal_valid.json` / `typical.json` / `edge_case.json`）。
 - 測試入口：`backend/tests/test_study_pack_schema_v1.py`。
+
+## T5 Dataset Schema Gate（Training Data）
+- 指令：
+  - `python backend/scripts/datasets/validate_study_pack_dataset.py --input <jsonl>`
+- 預設會使用 schema：`backend/docs/ai/study_pack_v1/study_pack.schema.v1.json`。
+- output 預設讀取每筆 record 的 `output` 欄位；可用 `--output-key` 指定其他欄位。
+- 產出檔案（預設與 input 同資料夾）：
+  - report：`<input_filename>.report.json`
+  - quarantine：`<input_filename>.quarantine.jsonl`
+- report 用途：提供總覽（`total/passed/failed/pass_rate`）與每個錯誤的 `line_number/record_id/error_path/message`。
+- quarantine 用途：收錄所有 fail 的原始 record，並附加 `validation_errors` 供後續人工排查或修復流程使用。

--- a/backend/scripts/datasets/validate_study_pack_dataset.py
+++ b/backend/scripts/datasets/validate_study_pack_dataset.py
@@ -1,0 +1,370 @@
+# backend/scripts/datasets/validate_study_pack_dataset.py
+"""Schema gate for Study Pack training dataset JSONL records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA_PATH = (
+    BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "study_pack.schema.v1.json"
+)
+RECORD_ID_KEYS = ("id", "uuid", "record_id", "sample_id")
+
+
+@dataclass(slots=True)
+class ValidationRunResult:
+    report: dict[str, Any]
+    report_path: Path
+    quarantine_path: Path
+    exit_code: int
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_report_path(input_path: Path) -> Path:
+    return input_path.with_name(f"{input_path.name}.report.json")
+
+
+def default_quarantine_path(input_path: Path) -> Path:
+    return input_path.with_name(f"{input_path.name}.quarantine.jsonl")
+
+
+def _is_non_empty(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def extract_record_id(record: dict[str, Any]) -> str | None:
+    for key in RECORD_ID_KEYS:
+        value = record.get(key)
+        if _is_non_empty(value):
+            return value.strip()
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return str(value)
+    return None
+
+
+def build_json_path(parts: list[Any]) -> str:
+    path = "$"
+    for part in parts:
+        if isinstance(part, int):
+            path += f"[{part}]"
+            continue
+        if isinstance(part, str) and part.isidentifier():
+            path += f".{part}"
+            continue
+        rendered = json.dumps(part, ensure_ascii=False)
+        path += f"[{rendered}]"
+    return path
+
+
+def _unwrap_code_fence(value: str) -> str:
+    text = value.strip()
+    if not text.startswith("```"):
+        return text
+
+    lines = text.splitlines()
+    if len(lines) < 2:
+        return text
+
+    first_line = lines[0].strip()
+    last_line = lines[-1].strip()
+    if not first_line.startswith("```") or last_line != "```":
+        return text
+
+    language = first_line[3:].strip().lower()
+    if language and language != "json":
+        return text
+
+    return "\n".join(lines[1:-1]).strip()
+
+
+def parse_output_as_object(output_value: Any, *, output_key: str) -> tuple[dict[str, Any] | None, list[dict[str, str]]]:
+    path = build_json_path([output_key])
+
+    if isinstance(output_value, dict):
+        return output_value, []
+
+    if isinstance(output_value, str):
+        payload = _unwrap_code_fence(output_value).strip()
+        if not payload:
+            return None, [{"error_path": path, "message": "output JSON string is empty"}]
+
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            return None, [
+                {
+                    "error_path": path,
+                    "message": f"output is not valid JSON: {exc.msg} (char {exc.pos})",
+                }
+            ]
+
+        if isinstance(parsed, str):
+            nested = parsed.strip()
+            if nested:
+                try:
+                    parsed = json.loads(nested)
+                except json.JSONDecodeError:
+                    pass
+
+        if not isinstance(parsed, dict):
+            return None, [{"error_path": path, "message": "output JSON must decode to an object"}]
+
+        return parsed, []
+
+    return None, [
+        {
+            "error_path": path,
+            "message": f"output must be object or JSON string, got {type(output_value).__name__}",
+        }
+    ]
+
+
+def _ensure_jsonl_file(input_path: Path) -> Path:
+    resolved = input_path.resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"input path does not exist: {input_path}")
+    if not resolved.is_file():
+        raise ValueError(f"input path must be a JSONL file: {input_path}")
+    return resolved
+
+
+def validate_study_pack_dataset(
+    *,
+    input_path: Path,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+    output_key: str = "output",
+    report_path: Path | None = None,
+    quarantine_path: Path | None = None,
+) -> ValidationRunResult:
+    if not output_key or not output_key.strip():
+        raise ValueError("output_key cannot be empty")
+
+    resolved_input = _ensure_jsonl_file(input_path)
+    resolved_schema = schema_path.resolve()
+
+    schema = json.loads(resolved_schema.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    validator = jsonschema.Draft202012Validator(schema)
+
+    if report_path is None:
+        report_path = default_report_path(resolved_input)
+    if quarantine_path is None:
+        quarantine_path = default_quarantine_path(resolved_input)
+
+    errors: list[dict[str, Any]] = []
+    quarantine_rows: list[dict[str, Any]] = []
+
+    total = 0
+    passed = 0
+    failed = 0
+
+    with resolved_input.open("r", encoding="utf-8") as file_obj:
+        for line_number, line in enumerate(file_obj, start=1):
+            payload = line.strip()
+            if not payload:
+                continue
+
+            total += 1
+            line_errors: list[dict[str, Any]] = []
+            record: Any = None
+            record_id: str | None = None
+
+            try:
+                record = json.loads(payload)
+            except json.JSONDecodeError as exc:
+                line_errors.append(
+                    {
+                        "line_number": line_number,
+                        "record_id": None,
+                        "error_path": "$",
+                        "message": f"record is not valid JSON: {exc.msg} (char {exc.pos})",
+                    }
+                )
+
+            if not line_errors:
+                if not isinstance(record, dict):
+                    line_errors.append(
+                        {
+                            "line_number": line_number,
+                            "record_id": None,
+                            "error_path": "$",
+                            "message": f"record must be a JSON object, got {type(record).__name__}",
+                        }
+                    )
+                else:
+                    record_id = extract_record_id(record)
+
+                    if output_key not in record:
+                        line_errors.append(
+                            {
+                                "line_number": line_number,
+                                "record_id": record_id,
+                                "error_path": build_json_path([output_key]),
+                                "message": f"missing output key: {output_key}",
+                            }
+                        )
+                    else:
+                        output_object, parse_errors = parse_output_as_object(
+                            record[output_key],
+                            output_key=output_key,
+                        )
+
+                        for parse_error in parse_errors:
+                            line_errors.append(
+                                {
+                                    "line_number": line_number,
+                                    "record_id": record_id,
+                                    "error_path": parse_error["error_path"],
+                                    "message": parse_error["message"],
+                                }
+                            )
+
+                        if output_object is not None:
+                            schema_errors = sorted(
+                                validator.iter_errors(output_object),
+                                key=lambda item: (list(item.path), item.message),
+                            )
+                            for schema_error in schema_errors:
+                                line_errors.append(
+                                    {
+                                        "line_number": line_number,
+                                        "record_id": record_id,
+                                        "error_path": build_json_path(
+                                            [output_key, *list(schema_error.path)]
+                                        ),
+                                        "message": schema_error.message,
+                                    }
+                                )
+
+            if line_errors:
+                failed += 1
+                errors.extend(line_errors)
+
+                validation_errors = [
+                    {
+                        "error_path": item["error_path"],
+                        "message": item["message"],
+                    }
+                    for item in line_errors
+                ]
+
+                if isinstance(record, dict):
+                    quarantined = dict(record)
+                    quarantined["validation_errors"] = validation_errors
+                elif record is None:
+                    quarantined = {
+                        "raw_line": payload,
+                        "validation_errors": validation_errors,
+                    }
+                else:
+                    quarantined = {
+                        "raw_record": record,
+                        "validation_errors": validation_errors,
+                    }
+                quarantine_rows.append(quarantined)
+            else:
+                passed += 1
+
+    pass_rate = 0.0 if total == 0 else passed / total
+    report = {
+        "validated_at": utc_now_iso(),
+        "schema_path": str(resolved_schema),
+        "input_path": str(resolved_input),
+        "output_key": output_key,
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "pass_rate": pass_rate,
+        "errors": errors,
+    }
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    quarantine_path.parent.mkdir(parents=True, exist_ok=True)
+    with quarantine_path.open("w", encoding="utf-8") as file_obj:
+        for row in quarantine_rows:
+            file_obj.write(json.dumps(row, ensure_ascii=False))
+            file_obj.write("\n")
+
+    exit_code = 0 if failed == 0 else 2
+    return ValidationRunResult(
+        report=report,
+        report_path=report_path,
+        quarantine_path=quarantine_path,
+        exit_code=exit_code,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Schema gate validation for Study Pack JSONL dataset")
+    parser.add_argument("--input", type=Path, required=True, help="Input JSONL path")
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_SCHEMA_PATH,
+        help=f"Study Pack schema path (default: {DEFAULT_SCHEMA_PATH})",
+    )
+    parser.add_argument(
+        "--output-key",
+        type=str,
+        default="output",
+        help="Record key containing schema target payload (default: output)",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Validation report JSON output path",
+    )
+    parser.add_argument(
+        "--quarantine",
+        type=Path,
+        default=None,
+        help="Quarantine JSONL output path for failed records",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = validate_study_pack_dataset(
+            input_path=args.input,
+            schema_path=args.schema,
+            output_key=args.output_key,
+            report_path=args.report,
+            quarantine_path=args.quarantine,
+        )
+    except Exception as exc:
+        print(f"validate_study_pack_dataset failed: {exc}", file=sys.stderr)
+        return 1
+
+    summary = result.report
+    print(
+        "Schema gate summary: "
+        f"total={summary['total']}, "
+        f"passed={summary['passed']}, "
+        f"failed={summary['failed']}, "
+        f"pass_rate={summary['pass_rate']:.4f}, "
+        f"report={result.report_path}, "
+        f"quarantine={result.quarantine_path}"
+    )
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/scripts/test_validate_study_pack_dataset.py
+++ b/backend/tests/scripts/test_validate_study_pack_dataset.py
@@ -1,0 +1,115 @@
+# backend/tests/scripts/test_validate_study_pack_dataset.py
+import json
+from pathlib import Path
+
+from scripts.datasets.validate_study_pack_dataset import validate_study_pack_dataset
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "study_pack.schema.v1.json"
+SAMPLES_DIR = BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "golden_samples"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as file_obj:
+        for row in rows:
+            file_obj.write(json.dumps(row, ensure_ascii=False))
+            file_obj.write("\n")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with path.open("r", encoding="utf-8") as file_obj:
+        for line in file_obj:
+            payload = line.strip()
+            if payload:
+                rows.append(json.loads(payload))
+    return rows
+
+
+def test_validate_study_pack_dataset_golden_samples_pass(tmp_path) -> None:
+    samples = [
+        _load_json(SAMPLES_DIR / "minimal_valid.json"),
+        _load_json(SAMPLES_DIR / "typical.json"),
+        _load_json(SAMPLES_DIR / "edge_case.json"),
+    ]
+
+    dataset_path = tmp_path / "golden_samples.jsonl"
+    _write_jsonl(
+        dataset_path,
+        [
+            {"id": "golden-1", "output": samples[0]},
+            {"id": "golden-2", "output": samples[1]},
+            {"id": "golden-3", "output": samples[2]},
+        ],
+    )
+
+    result = validate_study_pack_dataset(
+        input_path=dataset_path,
+        schema_path=SCHEMA_PATH,
+    )
+
+    assert result.exit_code == 0
+    assert result.report["total"] == 3
+    assert result.report["passed"] == 3
+    assert result.report["failed"] == 0
+    assert result.report["errors"] == []
+
+
+def test_validate_study_pack_dataset_mixed_records_report_and_quarantine(tmp_path) -> None:
+    valid_output = _load_json(SAMPLES_DIR / "minimal_valid.json")
+    invalid_output = dict(valid_output)
+    invalid_output.pop("schema_version")
+
+    dataset_path = tmp_path / "mixed.jsonl"
+    report_path = tmp_path / "mixed.report.json"
+    quarantine_path = tmp_path / "mixed.quarantine.jsonl"
+
+    _write_jsonl(
+        dataset_path,
+        [
+            {
+                "id": "row-pass-001",
+                "output": "```json\n" + json.dumps(valid_output, ensure_ascii=False) + "\n```",
+            },
+            {"uuid": "row-fail-001", "output": invalid_output},
+        ],
+    )
+
+    result = validate_study_pack_dataset(
+        input_path=dataset_path,
+        schema_path=SCHEMA_PATH,
+        report_path=report_path,
+        quarantine_path=quarantine_path,
+    )
+
+    assert result.exit_code == 2
+    assert result.report["total"] == 2
+    assert result.report["passed"] == 1
+    assert result.report["failed"] == 1
+
+    report = _load_json(report_path)
+    assert report["total"] == 2
+    assert report["passed"] == 1
+    assert report["failed"] == 1
+    assert report["pass_rate"] == 0.5
+
+    errors = report["errors"]
+    assert len(errors) >= 1
+    assert any(error["line_number"] == 2 for error in errors)
+    assert any(error["record_id"] == "row-fail-001" for error in errors)
+    assert any(error["error_path"] == "$.output" for error in errors)
+
+    quarantine_rows = _read_jsonl(quarantine_path)
+    assert len(quarantine_rows) == 1
+    quarantined = quarantine_rows[0]
+    assert quarantined["uuid"] == "row-fail-001"
+    assert "validation_errors" in quarantined
+    assert isinstance(quarantined["validation_errors"], list)
+    assert len(quarantined["validation_errors"]) >= 1
+    assert "error_path" in quarantined["validation_errors"][0]
+    assert "message" in quarantined["validation_errors"][0]


### PR DESCRIPTION
### 變更摘要

完成 AI 流程 T5（Schema Gate for Training Data）工程化落地：新增資料集驗證腳本，對訓練資料 JSONL 中的 `output`（可為 dict 或 JSON 字串 / `json code fence`）進行 Study Pack schema v1 驗證，輸出 validation report 與 quarantine 檔案，並以 exit code 支援 CI gate（pass=0 / fail=2 / exception=1）。

### 主要變更

* T5 dataset schema gate script

  * 新增 `backend/scripts/datasets/validate_study_pack_dataset.py`
  * CLI 參數：`--input` `--schema` `--output-key` `--report` `--quarantine`
  * 支援 `output` 為 `dict` 或 `str`（含 `json code fence`）解析後再驗證
  * 使用 `Draft202012Validator.iter_errors` 收集全部 schema 錯誤
  * 錯誤欄位：`line_number` / `record_id` / `error_path` / `message`
  * 產出：

    * report JSON（預設 `<input>.report.json`）
    * quarantine JSONL（預設 `<input>.quarantine.jsonl`，每筆 fail record 附 `validation_errors`）
  * Exit code：

    * 全部 pass：0
    * 任一 fail：2
    * 執行例外：1
  * Console summary 輸出 total/passed/failed/pass_rate/report/quarantine
* 測試

  * 新增 `backend/tests/scripts/test_validate_study_pack_dataset.py`
  * 驗證 golden samples（`minimal_valid.json` / `typical.json` / `edge_case.json`）皆可通過
  * 建立混合 JSONL（1 pass + 1 fail）驗證 report/quarantine 與 fail exit code 行為
* 文件

  * 更新 `backend/docs/ai/study_pack_v1/README.md`
  * 補上「T5 Dataset Schema Gate（Training Data）」執行方式與 report/quarantine 用途說明

### 為什麼要改

* 讓訓練資料在進入訓練前可被機械化 gate：不合 schema 的樣本可隔離並精準定位錯誤，便於 CI 阻擋與人工修復。
* 將 schema 驗證前移，降低後續訓練階段才暴露資料品質問題的成本。

### 如何驗證（本地測試）

在 `backend/`：

1. 單一測試檔

   * `pytest -q tests/scripts/test_validate_study_pack_dataset.py`
2. 全量後端測試

   * `pytest -q`
3. CLI（混合 pass/fail）

   * `python scripts/datasets/validate_study_pack_dataset.py --input <jsonl>`
   * 預期 fail 情境 exit code 為 2，並輸出 summary + report/quarantine 路徑
4. CLI（全 pass）

   * `python scripts/datasets/validate_study_pack_dataset.py --input <jsonl>`
   * 預期 exit code 為 0

### 安全/合規確認

* 未提交任何 `datasets_local/` 產物（僅程式碼 / 測試 / 文件）
* 未提交任何 secrets（.env、keys、token、連線字串等）
* `backend/requirements.txt` 已包含 `jsonschema>=4.0.0`，本次未新增依賴

### 檢查清單

* [x] 未追蹤任何 dataset 產物檔（尤其 `datasets_local/`）
* [x] CLI 可產出 report 與 quarantine，且 exit code 符合 gate 規則
* [x] golden samples schema 驗證通過
* [x] 混合資料（pass+fail）可正確 quarantine fail records 並附 `validation_errors`
* [x] `pytest` 全部通過（可重現）
