### PR TITLE
feat(t6): add training config schema + run init metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,8 @@ temp/
 uploads/
 backend/uploads/
 *.db
+backend/datasets_local/training/runs/**
+backend/datasets_local/training/artifacts/**
 
 # Source imports (do not commit)
 feature-dashboard-uploadmaterial-branch/

--- a/backend/docs/ai/training/README.md
+++ b/backend/docs/ai/training/README.md
@@ -1,0 +1,63 @@
+# Training Config v1（T6）
+
+此資料夾定義 T6 的訓練設定契約與 run 初始化流程，目標是讓後續訓練（T7）具備可重現、可追溯的 metadata 基礎。
+
+## 檔案
+- `training_config.schema.v1.json`：訓練設定 JSON Schema（Draft 2020-12）
+- `training_config.example.v1.yaml`：示範設定（小模型 + 保守超參數，不會自動觸發訓練）
+
+## 欄位說明（Schema v1）
+- `version`：固定 `v1`
+- `base_model`：基礎模型名稱（例如 `Qwen/Qwen3-0.6B`）
+- `training_method`：`lora` 或 `qlora`
+- `dataset.train_path`：訓練資料 JSONL 路徑（必要）
+- `dataset.valid_path`：驗證資料 JSONL 路徑（可選）
+- `dataset.dataset_version`：資料版本字串（可選；若未提供，仍會在 run init 時計算檔案 hash）
+- `hyperparams.learning_rate`
+- `hyperparams.epochs`
+- `hyperparams.per_device_train_batch_size`
+- `hyperparams.gradient_accumulation_steps`
+- `hyperparams.seed`
+- `hyperparams.max_seq_len`
+- `lora.r`
+- `lora.lora_alpha`
+- `lora.lora_dropout`
+- `lora.target_modules`：可選 target modules 清單
+- `output`：可選；若提供，僅允許 `runs_dir`
+- `output.runs_dir`：run 輸出根目錄（預設 `backend/datasets_local/training/runs`）
+
+### default 行為（重要）
+- JSON Schema 的 `default` 只是一種 annotation，不會在 validation 階段自動補值。
+- `validate_training_config.py` 只做驗證，不會修改 config。
+- `init_training_run.py` 會讀取 schema 內 `output.runs_dir.default` 作為預設值；若 schema 讀取失敗或缺值，才 fallback 到 `backend/datasets_local/training/runs`。
+- 因此 config 可省略 `output`，仍可正常 init run。
+
+## 驗證設定檔
+在 repo root 執行：
+
+```bash
+python backend/scripts/training/validate_training_config.py \
+  --config backend/docs/ai/training/training_config.example.v1.yaml
+```
+
+## 初始化 run metadata（不會訓練）
+在 repo root 執行：
+
+```bash
+python backend/scripts/training/init_training_run.py \
+  --config backend/docs/ai/training/training_config.example.v1.yaml
+```
+
+初始化後會在 `<runs_dir>/<run_id>/` 產出：
+- `run_meta.json`
+- `config.snapshot.yaml`
+- `run_summary.md`
+
+`run_meta.json` 至少包含：
+- `run_id`
+- `created_at_utc`
+- `git_commit`（若無法取得則為 `null`）
+- `config_path` + `config_snapshot`
+- `dataset_fingerprint`（`train/valid` 檔案內容 `sha256` + `dataset_version`）
+- `base_model`、`training_method`、`hyperparams`、`lora`
+- `output.runs_dir`（最終使用值：使用者設定或 schema default）

--- a/backend/docs/ai/training/training_config.example.v1.yaml
+++ b/backend/docs/ai/training/training_config.example.v1.yaml
@@ -1,0 +1,24 @@
+version: v1
+base_model: Qwen/Qwen3-0.6B
+training_method: lora
+
+dataset:
+  train_path: backend/datasets_local/exports/instruction_dataset.v1.train.jsonl
+  valid_path: backend/datasets_local/exports/instruction_dataset.v1.valid.jsonl
+  dataset_version: instruction_dataset.v1
+
+hyperparams:
+  learning_rate: 0.0002
+  epochs: 1
+  per_device_train_batch_size: 2
+  gradient_accumulation_steps: 8
+  seed: 42
+  max_seq_len: 1024
+
+lora:
+  r: 8
+  lora_alpha: 16
+  lora_dropout: 0.05
+  target_modules:
+    - q_proj
+    - v_proj

--- a/backend/docs/ai/training/training_config.schema.v1.json
+++ b/backend/docs/ai/training/training_config.schema.v1.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studydy.local/schemas/training_config.schema.v1.json",
+  "title": "Studydy Training Config v1",
+  "description": "Training config contract for reproducible run initialization.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "base_model",
+    "training_method",
+    "dataset",
+    "hyperparams",
+    "lora"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "v1",
+      "description": "Config schema version."
+    },
+    "base_model": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Base model identifier, for example Qwen/Qwen3-0.6B."
+    },
+    "training_method": {
+      "type": "string",
+      "enum": [
+        "lora",
+        "qlora"
+      ],
+      "description": "Parameter-efficient fine-tuning method."
+    },
+    "dataset": {
+      "$ref": "#/$defs/dataset"
+    },
+    "hyperparams": {
+      "$ref": "#/$defs/hyperparams"
+    },
+    "lora": {
+      "$ref": "#/$defs/lora"
+    },
+    "output": {
+      "$ref": "#/$defs/output"
+    }
+  },
+  "$defs": {
+    "dataset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "train_path"
+      ],
+      "properties": {
+        "train_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path to training JSONL dataset."
+        },
+        "valid_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional path to validation JSONL dataset."
+        },
+        "dataset_version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional dataset version label. If omitted, run init will still fingerprint by file hash."
+        }
+      }
+    },
+    "hyperparams": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "learning_rate",
+        "epochs",
+        "per_device_train_batch_size",
+        "gradient_accumulation_steps",
+        "seed",
+        "max_seq_len"
+      ],
+      "properties": {
+        "learning_rate": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "epochs": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "per_device_train_batch_size": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "gradient_accumulation_steps": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "seed": {
+          "type": "integer"
+        },
+        "max_seq_len": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "lora": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "r",
+        "lora_alpha",
+        "lora_dropout"
+      ],
+      "properties": {
+        "r": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "lora_alpha": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "lora_dropout": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "target_modules": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "runs_dir": {
+          "type": "string",
+          "minLength": 1,
+          "default": "backend/datasets_local/training/runs"
+        }
+      }
+    }
+  }
+}

--- a/backend/scripts/__init__.py
+++ b/backend/scripts/__init__.py
@@ -1,0 +1,2 @@
+# backend/scripts/__init__.py
+"""Backend script modules."""

--- a/backend/scripts/datasets/__init__.py
+++ b/backend/scripts/datasets/__init__.py
@@ -1,0 +1,2 @@
+# backend/scripts/datasets/__init__.py
+"""Dataset script modules."""

--- a/backend/scripts/training/__init__.py
+++ b/backend/scripts/training/__init__.py
@@ -1,0 +1,2 @@
+# backend/scripts/training/__init__.py
+"""Training script modules."""

--- a/backend/scripts/training/init_training_run.py
+++ b/backend/scripts/training/init_training_run.py
@@ -1,0 +1,434 @@
+# backend/scripts/training/init_training_run.py
+"""Initialize a reproducible training run folder and metadata (T6)."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import yaml
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = BACKEND_ROOT.parent
+
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from scripts.training.validate_training_config import (  # noqa: E402
+    TrainingConfigValidationResult,
+    validate_training_config_file,
+)
+
+
+DEFAULT_TRAINING_SCHEMA_PATH = (
+    BACKEND_ROOT / "docs" / "ai" / "training" / "training_config.schema.v1.json"
+)
+DEFAULT_RUNS_DIR_FALLBACK = "backend/datasets_local/training/runs"
+
+
+@dataclass(slots=True)
+class InitRunResult:
+    run_id: str
+    run_dir: Path
+    run_meta_path: Path
+    summary_path: Path
+    meta: dict[str, Any]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def generate_run_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"run-{timestamp}-{uuid4().hex[:8]}"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_obj:
+        while True:
+            chunk = file_obj.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def to_repo_relative(path: Path) -> str:
+    resolved = path.resolve()
+    for root in (REPO_ROOT, BACKEND_ROOT, Path.cwd()):
+        try:
+            return resolved.relative_to(root.resolve()).as_posix()
+        except ValueError:
+            continue
+    return resolved.as_posix()
+
+
+def _unique_paths(paths: list[Path]) -> list[Path]:
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        key = str(path.resolve())
+        if key in seen:
+            continue
+        unique.append(path)
+        seen.add(key)
+    return unique
+
+
+def _preferred_roots(path_obj: Path, config_dir: Path) -> list[Path]:
+    if path_obj.parts and path_obj.parts[0] == "backend":
+        return _unique_paths([REPO_ROOT, Path.cwd(), BACKEND_ROOT, config_dir])
+
+    if path_obj.parts and path_obj.parts[0] in {"datasets_local", "docs", "scripts", "app", "tests"}:
+        return _unique_paths([BACKEND_ROOT, Path.cwd(), REPO_ROOT, config_dir])
+
+    return _unique_paths([config_dir, Path.cwd(), BACKEND_ROOT, REPO_ROOT])
+
+
+def resolve_config_path(path_text: str, *, config_dir: Path, must_exist: bool) -> Path:
+    path_obj = Path(path_text)
+    if path_obj.is_absolute():
+        resolved = path_obj.resolve()
+        if must_exist and not resolved.exists():
+            raise FileNotFoundError(f"path does not exist: {path_text}")
+        return resolved
+
+    roots = _preferred_roots(path_obj, config_dir)
+    checked: list[str] = []
+    for root in roots:
+        candidate = (root / path_obj).resolve()
+        checked.append(candidate.as_posix())
+        if candidate.exists():
+            return candidate
+
+    if must_exist:
+        checked_preview = ", ".join(checked)
+        raise FileNotFoundError(f"path does not exist: {path_text}; checked: {checked_preview}")
+
+    return (roots[0] / path_obj).resolve()
+
+
+def _resolve_git_dir(repo_root: Path) -> Path | None:
+    git_path = repo_root / ".git"
+    if git_path.is_dir():
+        return git_path
+    if not git_path.is_file():
+        return None
+
+    text = git_path.read_text(encoding="utf-8").strip()
+    if not text.startswith("gitdir:"):
+        return None
+
+    git_dir_text = text.split(":", 1)[1].strip()
+    git_dir_path = Path(git_dir_text)
+    if not git_dir_path.is_absolute():
+        git_dir_path = (repo_root / git_dir_path).resolve()
+    if git_dir_path.is_dir():
+        return git_dir_path
+    return None
+
+
+def _read_packed_ref(git_dir: Path, ref_name: str) -> str | None:
+    packed_refs = git_dir / "packed-refs"
+    if not packed_refs.exists():
+        return None
+
+    with packed_refs.open("r", encoding="utf-8") as file_obj:
+        for line in file_obj:
+            payload = line.strip()
+            if not payload or payload.startswith("#") or payload.startswith("^"):
+                continue
+            columns = payload.split(" ", 1)
+            if len(columns) != 2:
+                continue
+            commit, ref = columns
+            if ref == ref_name:
+                return commit
+    return None
+
+
+def get_git_commit(repo_root: Path = REPO_ROOT) -> str | None:
+    git_dir = _resolve_git_dir(repo_root)
+    if git_dir is None:
+        return None
+
+    head_path = git_dir / "HEAD"
+    if not head_path.exists():
+        return None
+
+    head = head_path.read_text(encoding="utf-8").strip()
+    if head.startswith("ref:"):
+        ref_name = head.split(":", 1)[1].strip()
+        ref_path = git_dir / ref_name
+        if ref_path.exists():
+            commit = ref_path.read_text(encoding="utf-8").strip()
+        else:
+            commit = _read_packed_ref(git_dir, ref_name)
+    else:
+        commit = head
+
+    if isinstance(commit, str) and re.fullmatch(r"[0-9a-f]{40}", commit):
+        return commit
+    return None
+
+
+def _build_file_fingerprint(path_text: str, *, config_dir: Path) -> dict[str, Any]:
+    resolved = resolve_config_path(path_text, config_dir=config_dir, must_exist=True)
+    return {
+        "path": path_text,
+        "resolved_path": to_repo_relative(resolved),
+        "sha256": sha256_file(resolved),
+        "size_bytes": resolved.stat().st_size,
+    }
+
+
+def build_dataset_fingerprint(dataset: dict[str, Any], *, config_dir: Path) -> dict[str, Any]:
+    fingerprint: dict[str, Any] = {
+        "dataset_version": dataset.get("dataset_version"),
+        "train": _build_file_fingerprint(str(dataset["train_path"]), config_dir=config_dir),
+        "valid": None,
+    }
+
+    valid_path = dataset.get("valid_path")
+    if isinstance(valid_path, str) and valid_path.strip():
+        fingerprint["valid"] = _build_file_fingerprint(valid_path.strip(), config_dir=config_dir)
+
+    return fingerprint
+
+
+def _get_schema_runs_dir_default(
+    schema_path: Path,
+    *,
+    fallback: str = DEFAULT_RUNS_DIR_FALLBACK,
+) -> str:
+    try:
+        schema = json.loads(schema_path.resolve().read_text(encoding="utf-8"))
+    except Exception:
+        return fallback
+
+    if not isinstance(schema, dict):
+        return fallback
+
+    defs = schema.get("$defs")
+    if not isinstance(defs, dict):
+        return fallback
+
+    output = defs.get("output")
+    if not isinstance(output, dict):
+        return fallback
+
+    properties = output.get("properties")
+    if not isinstance(properties, dict):
+        return fallback
+
+    runs_dir = properties.get("runs_dir")
+    if not isinstance(runs_dir, dict):
+        return fallback
+
+    default_value = runs_dir.get("default")
+    if isinstance(default_value, str) and default_value.strip():
+        return default_value.strip()
+    return fallback
+
+
+def _resolve_runs_dir(
+    config: dict[str, Any],
+    *,
+    config_dir: Path,
+    default_runs_dir_text: str,
+) -> tuple[str, Path]:
+    output = config.get("output", {})
+    runs_dir_text = default_runs_dir_text
+    if isinstance(output, dict):
+        candidate = output.get("runs_dir")
+        if isinstance(candidate, str) and candidate.strip():
+            runs_dir_text = candidate.strip()
+
+    runs_dir_path = resolve_config_path(runs_dir_text, config_dir=config_dir, must_exist=False)
+    return runs_dir_text, runs_dir_path
+
+
+def write_run_summary(run_dir: Path, meta: dict[str, Any]) -> Path:
+    summary_path = run_dir / "run_summary.md"
+    dataset_fingerprint = meta["dataset_fingerprint"]
+    lines = [
+        "# Training Run Summary",
+        "",
+        f"- run_id: `{meta['run_id']}`",
+        f"- created_at_utc: `{meta['created_at_utc']}`",
+        f"- git_commit: `{meta['git_commit']}`",
+        f"- base_model: `{meta['base_model']}`",
+        f"- training_method: `{meta['training_method']}`",
+        f"- config_path: `{meta['config_path']}`",
+        f"- config_path_resolved: `{meta['config_path_resolved']}`",
+        "",
+        "## Dataset Fingerprint",
+        f"- dataset_version: `{dataset_fingerprint.get('dataset_version')}`",
+        (
+            f"- train: `{dataset_fingerprint['train']['resolved_path']}` "
+            f"(sha256=`{dataset_fingerprint['train']['sha256']}`)"
+        ),
+    ]
+
+    valid_fingerprint = dataset_fingerprint.get("valid")
+    if isinstance(valid_fingerprint, dict):
+        lines.append(
+            f"- valid: `{valid_fingerprint['resolved_path']}` "
+            f"(sha256=`{valid_fingerprint['sha256']}`)"
+        )
+    else:
+        lines.append("- valid: `null`")
+
+    lines.extend(
+        [
+            "",
+            "## Files",
+            "- `run_meta.json`",
+            "- `config.snapshot.yaml`",
+            "- `run_summary.md`",
+        ]
+    )
+
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return summary_path
+
+
+def _validated_config(
+    *,
+    config_path: Path,
+    schema_path: Path,
+) -> TrainingConfigValidationResult:
+    result = validate_training_config_file(config_path=config_path, schema_path=schema_path)
+    if not result.is_valid:
+        details = "\n".join(f"- {error}" for error in result.errors)
+        raise ValueError(f"invalid training config:\n{details}")
+    return result
+
+
+def init_training_run(
+    *,
+    config_path: Path,
+    schema_path: Path = DEFAULT_TRAINING_SCHEMA_PATH,
+) -> InitRunResult:
+    validation = _validated_config(config_path=config_path, schema_path=schema_path)
+    config = validation.config
+    if config is None:
+        raise ValueError("validated config should not be empty")
+
+    config_dir = validation.config_path.parent
+    schema_default_runs_dir = _get_schema_runs_dir_default(validation.schema_path)
+    runs_dir_text, runs_dir_path = _resolve_runs_dir(
+        config,
+        config_dir=config_dir,
+        default_runs_dir_text=schema_default_runs_dir,
+    )
+
+    run_id = generate_run_id()
+    run_dir = runs_dir_path / run_id
+    if run_dir.exists():
+        raise FileExistsError(f"run output already exists: {run_dir}")
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    snapshot_path = run_dir / "config.snapshot.yaml"
+    snapshot_path.write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+    dataset_fingerprint = build_dataset_fingerprint(config["dataset"], config_dir=config_dir)
+    created_at = utc_now_iso()
+    git_commit = get_git_commit()
+
+    meta: dict[str, Any] = {
+        "run_id": run_id,
+        "created_at_utc": created_at,
+        "git_commit": git_commit,
+        "config_path": str(config_path),
+        "config_path_resolved": to_repo_relative(validation.config_path),
+        "config_snapshot_path": "config.snapshot.yaml",
+        "config_snapshot": config,
+        "dataset_fingerprint": dataset_fingerprint,
+        "base_model": config["base_model"],
+        "training_method": config["training_method"],
+        "hyperparams": config["hyperparams"],
+        "lora": config["lora"],
+        "output": {
+            "runs_dir": runs_dir_text,
+            "resolved_runs_dir": to_repo_relative(runs_dir_path),
+            "resolved_run_dir": to_repo_relative(run_dir),
+        },
+    }
+
+    run_meta_path = run_dir / "run_meta.json"
+    run_meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    summary_path = write_run_summary(run_dir, meta)
+    return InitRunResult(
+        run_id=run_id,
+        run_dir=run_dir,
+        run_meta_path=run_meta_path,
+        summary_path=summary_path,
+        meta=meta,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Initialize T6 training run metadata.")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        required=True,
+        help="Path to training config YAML/JSON.",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_TRAINING_SCHEMA_PATH,
+        help=f"Training config schema path (default: {DEFAULT_TRAINING_SCHEMA_PATH})",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = init_training_run(config_path=args.config, schema_path=args.schema)
+    except ValueError as exc:
+        if str(exc).startswith("invalid training config:"):
+            print("FAIL: training config validation failed.", file=sys.stderr)
+            print(exc, file=sys.stderr)
+            return 2
+        print(f"init_training_run failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"init_training_run failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "run_id": result.run_id,
+                "run_dir": to_repo_relative(result.run_dir),
+                "run_meta_path": to_repo_relative(result.run_meta_path),
+                "run_summary_path": to_repo_relative(result.summary_path),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/training/validate_training_config.py
+++ b/backend/scripts/training/validate_training_config.py
@@ -1,0 +1,156 @@
+# backend/scripts/training/validate_training_config.py
+"""Validate T6 training config (YAML/JSON) with schema v1."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import yaml
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA_PATH = BACKEND_ROOT / "docs" / "ai" / "training" / "training_config.schema.v1.json"
+
+
+@dataclass(slots=True)
+class TrainingConfigValidationResult:
+    is_valid: bool
+    config: dict[str, Any] | None
+    config_path: Path
+    schema_path: Path
+    errors: list[str]
+
+
+def build_json_path(parts: list[Any]) -> str:
+    path = "$"
+    for part in parts:
+        if isinstance(part, int):
+            path += f"[{part}]"
+            continue
+        if isinstance(part, str) and part.isidentifier():
+            path += f".{part}"
+            continue
+        rendered = json.dumps(part, ensure_ascii=False)
+        path += f"[{rendered}]"
+    return path
+
+
+def load_config_document(config_path: Path) -> Any:
+    resolved = config_path.resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"config path does not exist: {config_path}")
+    if not resolved.is_file():
+        raise ValueError(f"config path must be a file: {config_path}")
+
+    text = resolved.read_text(encoding="utf-8")
+    suffix = resolved.suffix.lower()
+
+    if suffix == ".json":
+        return json.loads(text)
+    if suffix in {".yaml", ".yml"}:
+        return yaml.safe_load(text)
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return yaml.safe_load(text)
+
+
+def _load_schema(schema_path: Path) -> dict[str, Any]:
+    resolved = schema_path.resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"schema path does not exist: {schema_path}")
+    schema = json.loads(resolved.read_text(encoding="utf-8"))
+    if not isinstance(schema, dict):
+        raise ValueError(f"schema must be a JSON object: {schema_path}")
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return schema
+
+
+def format_validation_errors(errors: list[jsonschema.ValidationError]) -> list[str]:
+    formatted: list[str] = []
+    for error in errors:
+        error_path = build_json_path(list(error.absolute_path))
+        formatted.append(f"{error_path}: {error.message}")
+    return formatted
+
+
+def validate_training_config_file(
+    *,
+    config_path: Path,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+) -> TrainingConfigValidationResult:
+    resolved_config_path = config_path.resolve()
+    resolved_schema_path = schema_path.resolve()
+
+    config_data = load_config_document(resolved_config_path)
+    if not isinstance(config_data, dict):
+        raise ValueError("training config root must be an object")
+
+    schema = _load_schema(resolved_schema_path)
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(
+        validator.iter_errors(config_data),
+        key=lambda item: (list(item.absolute_path), item.message),
+    )
+    formatted_errors = format_validation_errors(errors)
+
+    return TrainingConfigValidationResult(
+        is_valid=not formatted_errors,
+        config=config_data,
+        config_path=resolved_config_path,
+        schema_path=resolved_schema_path,
+        errors=formatted_errors,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate T6 training config against schema v1.")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        required=True,
+        help="Path to training config YAML/JSON.",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_SCHEMA_PATH,
+        help=f"Training config schema path (default: {DEFAULT_SCHEMA_PATH})",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = validate_training_config_file(
+            config_path=args.config,
+            schema_path=args.schema,
+        )
+    except Exception as exc:
+        print(f"validate_training_config failed: {exc}", file=sys.stderr)
+        return 1
+
+    if not result.is_valid:
+        print("FAIL: training config validation failed.", file=sys.stderr)
+        print(f"config: {result.config_path}", file=sys.stderr)
+        print(f"schema: {result.schema_path}", file=sys.stderr)
+        for error in result.errors:
+            print(f"- {error}", file=sys.stderr)
+        return 2
+
+    print("PASS: training config validation succeeded.")
+    print(f"config: {result.config_path}")
+    print(f"schema: {result.schema_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/scripts/test_init_training_run.py
+++ b/backend/tests/scripts/test_init_training_run.py
@@ -1,0 +1,186 @@
+# backend/tests/scripts/test_init_training_run.py
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+from scripts.training.init_training_run import (
+    DEFAULT_RUNS_DIR_FALLBACK,
+    init_training_run,
+)
+from scripts.training.validate_training_config import DEFAULT_SCHEMA_PATH
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file_obj:
+        while True:
+            chunk = file_obj.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _build_config_without_output(train_path: Path, valid_path: Path) -> dict:
+    return {
+        "version": "v1",
+        "base_model": "Qwen/Qwen3-0.6B",
+        "training_method": "lora",
+        "dataset": {
+            "train_path": str(train_path),
+            "valid_path": str(valid_path),
+            "dataset_version": "instruction_dataset.v1",
+        },
+        "hyperparams": {
+            "learning_rate": 0.0002,
+            "epochs": 1,
+            "per_device_train_batch_size": 2,
+            "gradient_accumulation_steps": 8,
+            "seed": 42,
+            "max_seq_len": 1024,
+        },
+        "lora": {
+            "r": 8,
+            "lora_alpha": 16,
+            "lora_dropout": 0.05,
+            "target_modules": ["q_proj", "v_proj"],
+        },
+    }
+
+
+def test_init_training_run_creates_metadata_and_fingerprint(tmp_path) -> None:
+    train_path = tmp_path / "instruction_dataset.v1.train.jsonl"
+    valid_path = tmp_path / "instruction_dataset.v1.valid.jsonl"
+    train_path.write_text('{"id":"train-1","text":"hello"}\n', encoding="utf-8")
+    valid_path.write_text('{"id":"valid-1","text":"world"}\n', encoding="utf-8")
+
+    runs_dir = tmp_path / "runs"
+    config = {
+        "version": "v1",
+        "base_model": "Qwen/Qwen3-0.6B",
+        "training_method": "lora",
+        "dataset": {
+            "train_path": str(train_path),
+            "valid_path": str(valid_path),
+            "dataset_version": "instruction_dataset.v1",
+        },
+        "hyperparams": {
+            "learning_rate": 0.0002,
+            "epochs": 1,
+            "per_device_train_batch_size": 2,
+            "gradient_accumulation_steps": 8,
+            "seed": 42,
+            "max_seq_len": 1024,
+        },
+        "lora": {
+            "r": 8,
+            "lora_alpha": 16,
+            "lora_dropout": 0.05,
+            "target_modules": ["q_proj", "v_proj"],
+        },
+        "output": {
+            "runs_dir": str(runs_dir),
+        },
+    }
+    config_path = tmp_path / "training_config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+    result = init_training_run(config_path=config_path)
+
+    assert re.fullmatch(r"run-\d{8}T\d{6}Z-[0-9a-f]{8}", result.run_id)
+    assert result.run_dir.exists()
+    assert result.run_meta_path.exists()
+    assert result.summary_path.exists()
+    assert (result.run_dir / "config.snapshot.yaml").exists()
+
+    meta = json.loads(result.run_meta_path.read_text(encoding="utf-8"))
+    assert meta["run_id"] == result.run_id
+    assert meta["base_model"] == "Qwen/Qwen3-0.6B"
+    assert meta["training_method"] == "lora"
+    assert meta["dataset_fingerprint"]["dataset_version"] == "instruction_dataset.v1"
+    assert meta["dataset_fingerprint"]["train"]["sha256"] == _sha256(train_path)
+    assert meta["dataset_fingerprint"]["valid"]["sha256"] == _sha256(valid_path)
+
+
+def test_init_training_run_without_output_uses_schema_default(tmp_path) -> None:
+    train_path = tmp_path / "instruction_dataset.v1.train.jsonl"
+    valid_path = tmp_path / "instruction_dataset.v1.valid.jsonl"
+    train_path.write_text('{"id":"train-1","text":"hello"}\n', encoding="utf-8")
+    valid_path.write_text('{"id":"valid-1","text":"world"}\n', encoding="utf-8")
+
+    schema = json.loads(DEFAULT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema_default_runs_dir = str(tmp_path / "schema_default_runs")
+    schema["$defs"]["output"]["properties"]["runs_dir"]["default"] = schema_default_runs_dir
+    schema_path = tmp_path / "training_config.schema.v1.json"
+    schema_path.write_text(json.dumps(schema, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    config = _build_config_without_output(train_path, valid_path)
+    config_path = tmp_path / "training_config_without_output.yaml"
+    config_path.write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+    result = init_training_run(config_path=config_path, schema_path=schema_path)
+
+    meta = json.loads(result.run_meta_path.read_text(encoding="utf-8"))
+    assert meta["output"]["runs_dir"] == schema_default_runs_dir
+    assert result.run_dir.parent == Path(schema_default_runs_dir).resolve()
+    assert meta["dataset_fingerprint"]["train"]["sha256"] == _sha256(train_path)
+
+
+def test_init_training_run_is_cwd_independent(monkeypatch, tmp_path) -> None:
+    train_path = tmp_path / "instruction_dataset.v1.train.jsonl"
+    valid_path = tmp_path / "instruction_dataset.v1.valid.jsonl"
+    train_path.write_text('{"id":"train-1","text":"hello"}\n', encoding="utf-8")
+    valid_path.write_text('{"id":"valid-1","text":"world"}\n', encoding="utf-8")
+
+    config = _build_config_without_output(train_path, valid_path)
+    config_path = tmp_path / "training_config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+    other_cwd = tmp_path / "other-cwd"
+    other_cwd.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(other_cwd)
+
+    result = init_training_run(config_path=config_path.resolve())
+    meta = json.loads(result.run_meta_path.read_text(encoding="utf-8"))
+
+    assert result.run_dir.exists()
+    assert result.run_meta_path.exists()
+    assert meta["output"]["runs_dir"]
+
+
+def test_init_training_run_without_schema_default_uses_fallback(tmp_path) -> None:
+    train_path = tmp_path / "instruction_dataset.v1.train.jsonl"
+    valid_path = tmp_path / "instruction_dataset.v1.valid.jsonl"
+    train_path.write_text('{"id":"train-1","text":"hello"}\n', encoding="utf-8")
+    valid_path.write_text('{"id":"valid-1","text":"world"}\n', encoding="utf-8")
+
+    schema = json.loads(DEFAULT_SCHEMA_PATH.read_text(encoding="utf-8"))
+    del schema["$defs"]["output"]["properties"]["runs_dir"]["default"]
+    schema_path = tmp_path / "training_config.schema.v1.json"
+    schema_path.write_text(json.dumps(schema, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    config = _build_config_without_output(train_path, valid_path)
+    config_path = tmp_path / "training_config_without_output.yaml"
+    config_path.write_text(
+        yaml.safe_dump(config, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+    result = init_training_run(config_path=config_path, schema_path=schema_path)
+
+    meta = json.loads(result.run_meta_path.read_text(encoding="utf-8"))
+    assert meta["output"]["runs_dir"] == DEFAULT_RUNS_DIR_FALLBACK

--- a/backend/tests/scripts/test_validate_training_config.py
+++ b/backend/tests/scripts/test_validate_training_config.py
@@ -1,0 +1,107 @@
+# backend/tests/scripts/test_validate_training_config.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from scripts.training.validate_training_config import (
+    DEFAULT_SCHEMA_PATH,
+    validate_training_config_file,
+)
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_CONFIG_PATH = BACKEND_ROOT / "docs" / "ai" / "training" / "training_config.example.v1.yaml"
+
+
+def test_validate_training_config_example_pass() -> None:
+    result = validate_training_config_file(
+        config_path=EXAMPLE_CONFIG_PATH,
+        schema_path=DEFAULT_SCHEMA_PATH,
+    )
+
+    assert result.is_valid
+    assert result.errors == []
+    assert result.config is not None
+    assert result.config["base_model"] == "Qwen/Qwen3-0.6B"
+
+
+def test_validate_training_config_without_output_pass(tmp_path) -> None:
+    config_without_output = {
+        "version": "v1",
+        "base_model": "Qwen/Qwen3-0.6B",
+        "training_method": "lora",
+        "dataset": {
+            "train_path": "backend/datasets_local/exports/instruction_dataset.v1.train.jsonl",
+            "valid_path": "backend/datasets_local/exports/instruction_dataset.v1.valid.jsonl",
+            "dataset_version": "instruction_dataset.v1",
+        },
+        "hyperparams": {
+            "learning_rate": 0.0002,
+            "epochs": 1,
+            "per_device_train_batch_size": 2,
+            "gradient_accumulation_steps": 8,
+            "seed": 42,
+            "max_seq_len": 1024,
+        },
+        "lora": {
+            "r": 8,
+            "lora_alpha": 16,
+            "lora_dropout": 0.05,
+            "target_modules": ["q_proj", "v_proj"],
+        },
+    }
+    config_path = tmp_path / "training_config_without_output.yaml"
+    config_path.write_text(
+        yaml.safe_dump(config_without_output, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+    result = validate_training_config_file(
+        config_path=config_path,
+        schema_path=DEFAULT_SCHEMA_PATH,
+    )
+
+    assert result.is_valid
+    assert result.errors == []
+
+
+def test_validate_training_config_missing_required_field_fail(tmp_path) -> None:
+    invalid_config = {
+        "version": "v1",
+        "training_method": "lora",
+        "dataset": {
+            "train_path": "backend/datasets_local/exports/instruction_dataset.v1.train.jsonl",
+        },
+        "hyperparams": {
+            "learning_rate": 0.0002,
+            "epochs": 1,
+            "per_device_train_batch_size": 2,
+            "gradient_accumulation_steps": 8,
+            "seed": 42,
+            "max_seq_len": 1024,
+        },
+        "lora": {
+            "r": 8,
+            "lora_alpha": 16,
+            "lora_dropout": 0.05,
+        },
+        "output": {
+            "runs_dir": "backend/datasets_local/training/runs",
+        },
+    }
+    config_path = tmp_path / "invalid_training_config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(invalid_config, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+    result = validate_training_config_file(
+        config_path=config_path,
+        schema_path=DEFAULT_SCHEMA_PATH,
+    )
+
+    assert not result.is_valid
+    assert len(result.errors) >= 1
+    assert any("base_model" in error for error in result.errors)


### PR DESCRIPTION
### 變更摘要
完成 AI 流程 T6（Training config schema + validate CLI + run 初始化與 metadata 版本記錄）工程化落地：新增 training config schema v1 與 example config，提供 config 驗證 CLI，並新增 run 初始化腳本產出可追溯的 run_meta.json / config snapshot / run summary（包含 dataset sha256 fingerprint、git commit、最終 runs_dir 解析結果）。不包含任何訓練流程。

### 主要變更
- T6 training config schema & docs
  - 新增/更新 `backend/docs/ai/training/training_config.schema.v1.json`
  - 新增/更新 `backend/docs/ai/training/training_config.example.v1.yaml`
  - 更新 `backend/docs/ai/training/README.md`（欄位說明、output 可省略、runs_dir default 行為）
- CLI：validate training config
  - 新增 `backend/scripts/training/validate_training_config.py`
  - 支援 YAML/JSON config，使用 Draft202012Validator 驗證
  - Exit code：pass=0 / schema fail=2 / exception=1
- Run 初始化與 metadata 版本記錄
  - 新增 `backend/scripts/training/init_training_run.py`
  - 產生 `run-YYYYMMDDTHHMMSSZ-<8hex>` run_id，建立 run 目錄
  - 輸出 `run_meta.json`（含 created_at_utc/git_commit/config_snapshot/dataset_fingerprint/base_model/training_method/hyperparams/lora/output.runs_dir）
  - 額外輸出 `config.snapshot.yaml`、`run_summary.md`
  - schema path 與 cwd 無關（以 Path(__file__).resolve() 推導），並對 schema default 讀取加入穩健 fallback
- scripts package 結構統一
  - 新增 `backend/scripts/__init__.py`
  - 新增 `backend/scripts/training/__init__.py`
  - 新增 `backend/scripts/datasets/__init__.py`
- .gitignore
  - 忽略 `backend/datasets_local/training/runs/**` 與 `backend/datasets_local/training/artifacts/**`，避免 run 產物進版控
- 測試
  - 更新/新增 scripts tests，覆蓋：
    - output 可省略仍可 validate pass
    - init 在不同 cwd 下仍可正常建立 run
    - schema default 缺失時 fallback 行為

### 為什麼要改
- 建立可重現/可追溯的訓練設定與 run 版本治理基礎：任何一次 run 都能回溯到 config snapshot、資料集指紋（sha256）與程式版本（git commit）。
- 將訓練前置檢查工程化，降低後續訓練階段才暴露設定/資料問題的成本。

### 如何驗證（本地測試）
在 repo root：
1) Validate example config
- `./.venv/bin/python backend/scripts/training/validate_training_config.py --config backend/docs/ai/training/training_config.example.v1.yaml`

2) Init run（3 種 cwd）
- repo root：
  - `./.venv/bin/python backend/scripts/training/init_training_run.py --config backend/docs/ai/training/training_config.example.v1.yaml`
- backend 目錄：
  - `cd backend && ../.venv/bin/python scripts/training/init_training_run.py --config docs/ai/training/training_config.example.v1.yaml`
- /tmp（絕對路徑）：
  - `REPO="$HOME/projects/Studydy"; cd /tmp && "$REPO/.venv/bin/python" "$REPO/backend/scripts/training/init_training_run.py" --config "$REPO/backend/docs/ai/training/training_config.example.v1.yaml"`

3) pytest（scripts tests）
- `cd backend && ../.venv/bin/pytest -q tests/scripts`

### 安全/合規確認
- 未提交任何 `datasets_local/` 產物（僅程式碼 / 測試 / 文件），run/artifacts 已在 .gitignore 排除。
- 未提交任何 secrets（.env、keys、token、連線字串等）。
- 既有依賴（PyYAML、jsonschema）已存在，未額外新增依賴。

### 檢查清單
- [x] 未追蹤任何 training run 產物（datasets_local/training/runs、artifacts）
- [x] validate CLI exit code 與錯誤輸出符合預期
- [x] init 會產生 run_id、run_meta.json、config snapshot、run summary
- [x] dataset sha256 fingerprint 以串流方式計算
- [x] scripts tests 全數通過（可重現）