### PR TITLE
T0/T3/T4/T5: multi-agent schemas + chunk locator + task-based dataset validation

### DIFF
--- a/backend/docs/ai/datasets/document_chunks.schema.v1.json
+++ b/backend/docs/ai/datasets/document_chunks.schema.v1.json
@@ -32,7 +32,8 @@
         "sha256",
         "dataset_id",
         "created_at",
-        "char_count"
+        "char_count",
+        "locator"
       ],
       "properties": {
         "source_relative_path": {
@@ -58,6 +59,9 @@
         "char_count": {
           "type": "integer",
           "minimum": 1
+        },
+        "locator": {
+          "$ref": "#/$defs/locator"
         },
         "page_start": {
           "type": "integer",
@@ -89,14 +93,107 @@
         "heading": {
           "type": "string"
         }
+      }
+    },
+    "locator": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "source_file": {
+          "type": "string",
+          "minLength": 1
+        },
+        "document_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "page": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "page_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "page_end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "slide_index": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "slide_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "slide_end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "paragraph_index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "paragraph_start": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "paragraph_end": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "chunk_start_char": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "chunk_end_char": {
+          "type": "integer",
+          "minimum": 0
+        }
       },
       "allOf": [
         {
           "anyOf": [
             {
               "required": [
+                "source_file"
+              ]
+            },
+            {
+              "required": [
+                "document_id"
+              ]
+            }
+          ]
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "page"
+              ]
+            },
+            {
+              "required": [
                 "page_start",
                 "page_end"
+              ]
+            },
+            {
+              "required": [
+                "slide_index"
+              ]
+            },
+            {
+              "required": [
+                "slide_start",
+                "slide_end"
+              ]
+            },
+            {
+              "required": [
+                "paragraph_index"
               ]
             },
             {
@@ -107,8 +204,8 @@
             },
             {
               "required": [
-                "slide_start",
-                "slide_end"
+                "chunk_start_char",
+                "chunk_end_char"
               ]
             }
           ]

--- a/backend/docs/ai/datasets/instruction_dataset_v1/README.md
+++ b/backend/docs/ai/datasets/instruction_dataset_v1/README.md
@@ -11,6 +11,7 @@
 - `id`: instruction sample id（例：`ins-ch-...`）
 - `dataset_version`: 固定 `instruction_dataset.v1`
 - `split`: `train` / `valid` / `test`（由 `--split` + `--seed` 決定）
+- `task`: 任務類型（目前 MVP 先產 `domain`，保留 `question`/`tutor` 擴充位）
 - `chunk_id`: 對應 T3 chunk id
 - `source`: 追溯資訊
 - `meta`: 原始 chunk meta（保留定位與來源欄位）
@@ -44,6 +45,7 @@ python backend/scripts/datasets/build_instruction_dataset.py \
   --input-format jsonl \
   --out-dir backend/datasets_local/exports \
   --study-pack-schema backend/docs/ai/study_pack_v1/study_pack.schema.v1.json \
+  --task domain \
   --split train:0.9,valid:0.1 \
   --seed 42 \
   --max-context-chars 8000 \

--- a/backend/docs/ai/question_v1/README.md
+++ b/backend/docs/ai/question_v1/README.md
@@ -1,0 +1,17 @@
+# Question Schema v1
+
+這個資料夾提供 Question Agent 的最小輸出契約。
+目前先定義 `question_item.schema.v1.json`，讓題目資料可以穩定驗證。
+
+欄位重點：
+- `question_id`：題目唯一識別碼。
+- `concept_id`：題目對應的概念代碼。
+- `difficulty`：題目難度標記。
+- `stem`：題幹內容。
+- `options`：選項陣列（只有選擇題才需要）。
+- `answer_key`：正解（字串、索引或答案集合）。
+- `rationale`：解題說明。
+- `evidence_refs`：引用來源清單，至少要有 `chunk_id` 與 `locator`。
+
+`locator` 用來回到原始教材位置（頁碼、段落、投影片或字元範圍）。
+這份 schema 目標是先支援 Question Agent 的最小可用流程。

--- a/backend/docs/ai/question_v1/question_item.schema.v1.json
+++ b/backend/docs/ai/question_v1/question_item.schema.v1.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studydy.local/schemas/question_v1/question_item.schema.v1.json",
+  "title": "Studydy Question Item v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "question_id",
+    "concept_id",
+    "difficulty",
+    "stem",
+    "answer_key",
+    "rationale",
+    "evidence_refs"
+  ],
+  "properties": {
+    "question_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "concept_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "difficulty": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stem": {
+      "type": "string",
+      "minLength": 1
+    },
+    "options": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 2
+    },
+    "answer_key": {
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        }
+      ]
+    },
+    "rationale": {
+      "type": "string",
+      "minLength": 1
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/evidenceRef"
+      }
+    }
+  },
+  "$defs": {
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "chunk_id",
+        "locator"
+      ],
+      "properties": {
+        "chunk_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "locator": {
+          "$ref": "#/$defs/locator"
+        }
+      }
+    },
+    "locator": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "source_file": {
+          "type": "string",
+          "minLength": 1
+        },
+        "document_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "page": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "page_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "page_end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "slide_index": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "paragraph_start": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "paragraph_end": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "chunk_start_char": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "chunk_end_char": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "source_file"
+              ]
+            },
+            {
+              "required": [
+                "document_id"
+              ]
+            }
+          ]
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "page"
+              ]
+            },
+            {
+              "required": [
+                "page_start",
+                "page_end"
+              ]
+            },
+            {
+              "required": [
+                "slide_index"
+              ]
+            },
+            {
+              "required": [
+                "paragraph_start",
+                "paragraph_end"
+              ]
+            },
+            {
+              "required": [
+                "chunk_start_char",
+                "chunk_end_char"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/backend/docs/ai/student_v1/README.md
+++ b/backend/docs/ai/student_v1/README.md
@@ -1,0 +1,13 @@
+# Student Schema v1
+
+這個資料夾定義 Student Model 事件資料的最小契約。
+目前提供 `student_event.schema.v1.json`，先聚焦事件記錄一致性。
+
+欄位重點：
+- `event_type`：事件類型（例如答題提交、學習停留）。
+- `concept_id` 或 `ref_id`：事件關聯的概念或外部參照，至少要有一個。
+- `is_correct`：事件是否正確（布林值）。
+- `payload.time_spent_ms`：耗時毫秒數，固定放在 payload 內。
+
+此設計讓資料可先穩定落地，後續再依分析需求新增更多 payload 欄位。
+核心要求是欄位固定且可驗證，避免事件資料格式漂移。

--- a/backend/docs/ai/student_v1/student_event.schema.v1.json
+++ b/backend/docs/ai/student_v1/student_event.schema.v1.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studydy.local/schemas/student_v1/student_event.schema.v1.json",
+  "title": "Studydy Student Event v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_type",
+    "is_correct",
+    "payload"
+  ],
+  "properties": {
+    "event_type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "concept_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ref_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "is_correct": {
+      "type": "boolean"
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "time_spent_ms"
+      ],
+      "properties": {
+        "time_spent_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "anyOf": [
+        {
+          "required": [
+            "concept_id"
+          ]
+        },
+        {
+          "required": [
+            "ref_id"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/docs/ai/tutor_v1/README.md
+++ b/backend/docs/ai/tutor_v1/README.md
@@ -1,0 +1,18 @@
+# Tutor Schema v1
+
+這個資料夾提供 Tutor Agent 的最小輸出契約。
+目前分成策略層與訊息層兩份 schema。
+
+`tutor_action_plan.schema.v1.json` 重點：
+- `action_type`：這一步要做的教學動作。
+- `target_concepts`：目標概念陣列。
+- `difficulty_target`：預期難度區間。
+- `hint_level`：提示強度（0~5）。
+
+`tutor_message.schema.v1.json` 重點：
+- `summary`：本輪重點摘要。
+- `feedback`：對學生當下表現的回饋。
+- `next_steps`：後續建議步驟。
+- `evidence_refs`：引用教材來源（含 `chunk_id` + `locator`）。
+
+這些欄位先確保 Tutor 輸出可驗證、可追溯，後續再擴充語氣或策略細節。

--- a/backend/docs/ai/tutor_v1/tutor_action_plan.schema.v1.json
+++ b/backend/docs/ai/tutor_v1/tutor_action_plan.schema.v1.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studydy.local/schemas/tutor_v1/tutor_action_plan.schema.v1.json",
+  "title": "Studydy Tutor Action Plan v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "action_type",
+    "target_concepts",
+    "difficulty_target",
+    "hint_level"
+  ],
+  "properties": {
+    "action_type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "target_concepts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "difficulty_target": {
+      "type": "string",
+      "minLength": 1
+    },
+    "hint_level": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/backend/docs/ai/tutor_v1/tutor_message.schema.v1.json
+++ b/backend/docs/ai/tutor_v1/tutor_message.schema.v1.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://studydy.local/schemas/tutor_v1/tutor_message.schema.v1.json",
+  "title": "Studydy Tutor Message v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "summary",
+    "feedback",
+    "next_steps",
+    "evidence_refs"
+  ],
+  "properties": {
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "feedback": {
+      "type": "string",
+      "minLength": 1
+    },
+    "next_steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/evidenceRef"
+      }
+    }
+  },
+  "$defs": {
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "chunk_id",
+        "locator"
+      ],
+      "properties": {
+        "chunk_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "locator": {
+          "$ref": "#/$defs/locator"
+        }
+      }
+    },
+    "locator": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "source_file": {
+          "type": "string",
+          "minLength": 1
+        },
+        "document_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "page": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "page_start": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "page_end": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "slide_index": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "paragraph_start": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "paragraph_end": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "chunk_start_char": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "chunk_end_char": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "required": [
+                "source_file"
+              ]
+            },
+            {
+              "required": [
+                "document_id"
+              ]
+            }
+          ]
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "page"
+              ]
+            },
+            {
+              "required": [
+                "page_start",
+                "page_end"
+              ]
+            },
+            {
+              "required": [
+                "slide_index"
+              ]
+            },
+            {
+              "required": [
+                "paragraph_start",
+                "paragraph_end"
+              ]
+            },
+            {
+              "required": [
+                "chunk_start_char",
+                "chunk_end_char"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/backend/scripts/datasets/build_chunks.py
+++ b/backend/scripts/datasets/build_chunks.py
@@ -74,6 +74,13 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _build_document_id(*, dataset_id: str, source_relative_path: str, sha256: str) -> str:
+    digest = hashlib.sha256(
+        f"{dataset_id}:{source_relative_path}:{sha256}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"doc-{digest}"
+
+
 def _infer_backend_root(manifest_path: Path) -> Path:
     for candidate in [manifest_path.parent, *manifest_path.parents]:
         if candidate.name == "backend":
@@ -451,6 +458,41 @@ def _ensure_supported(path: Path) -> None:
         raise ValueError(f"Unsupported file type for T3 chunking: {path}")
 
 
+def _build_locator(
+    *,
+    locator_key: str,
+    span: ChunkSpan,
+    source_relative_path: str,
+    document_id: str,
+    chunk_start_char: int,
+    chunk_end_char: int,
+) -> dict[str, Any]:
+    locator: dict[str, Any] = {
+        "source_file": source_relative_path,
+        "document_id": document_id,
+        "chunk_start_char": chunk_start_char,
+        "chunk_end_char": chunk_end_char,
+    }
+
+    if locator_key == "page":
+        locator["page_start"] = span.start
+        locator["page_end"] = span.end
+        if span.start == span.end:
+            locator["page"] = span.start
+    elif locator_key == "paragraph":
+        locator["paragraph_start"] = span.start
+        locator["paragraph_end"] = span.end
+        if span.start == span.end:
+            locator["paragraph_index"] = span.start
+    elif locator_key == "slide":
+        locator["slide_index"] = span.start
+        if span.start != span.end:
+            locator["slide_start"] = span.start
+            locator["slide_end"] = span.end
+
+    return locator
+
+
 def build_dataset_chunks(
     *,
     manifest_path: Path,
@@ -520,8 +562,27 @@ def build_dataset_chunks(
                 file_type = selected_path.suffix.lower().lstrip(".")
 
             sha256 = _sha256_file(selected_path)
+            document_id = _build_document_id(
+                dataset_id=dataset_id,
+                source_relative_path=source_relative_path,
+                sha256=sha256,
+            )
+            file_char_cursor = 0
 
             for span in spans:
+                chunk_start_char = file_char_cursor
+                chunk_end_char = chunk_start_char + len(span.text)
+                file_char_cursor = chunk_end_char
+
+                locator = _build_locator(
+                    locator_key=extracted.locator_key,
+                    span=span,
+                    source_relative_path=source_relative_path,
+                    document_id=document_id,
+                    chunk_start_char=chunk_start_char,
+                    chunk_end_char=chunk_end_char,
+                )
+
                 meta: dict[str, Any] = {
                     "source_relative_path": source_relative_path,
                     "file_type": file_type,
@@ -529,6 +590,7 @@ def build_dataset_chunks(
                     "dataset_id": dataset_id,
                     "created_at": created_at,
                     "char_count": len(span.text),
+                    "locator": locator,
                 }
                 if extracted.locator_key == "page":
                     meta["page_start"] = span.start

--- a/backend/scripts/datasets/build_instruction_dataset.py
+++ b/backend/scripts/datasets/build_instruction_dataset.py
@@ -26,6 +26,10 @@ PREFERENCE_DATASET_VERSION = "preference_dataset.v1"
 PROMPT_COMPLETION = "prompt_completion"
 CONVERSATIONAL = "conversational"
 FORMAT_CHOICES = (PROMPT_COMPLETION, CONVERSATIONAL)
+TASK_DOMAIN = "domain"
+TASK_QUESTION = "question"
+TASK_TUTOR = "tutor"
+TASK_CHOICES = (TASK_DOMAIN, TASK_QUESTION, TASK_TUTOR)
 
 LOCATOR_KEYS = (
     "page_start",
@@ -200,6 +204,12 @@ def build_study_pack_output(context: str) -> dict[str, Any]:
     }
 
 
+def build_output_by_task(*, task: str, context: str) -> dict[str, Any]:
+    if task == TASK_DOMAIN:
+        return build_study_pack_output(context)
+    raise NotImplementedError(f"task `{task}` is not implemented yet in build_instruction_dataset")
+
+
 def build_locator(meta: dict[str, Any]) -> dict[str, Any]:
     locator: dict[str, Any] = {}
     for key in LOCATOR_KEYS:
@@ -228,6 +238,7 @@ def infer_doc_id(meta: dict[str, Any]) -> str:
 
 def build_prompts(
     *,
+    task: str,
     chunk_id: str,
     source_relative_path: str,
     locator: dict[str, Any],
@@ -236,7 +247,7 @@ def build_prompts(
 ) -> tuple[str, str]:
     system_prompt = (
         "You are a Studydy dataset annotation assistant. "
-        "Return exactly one JSON object that must satisfy Study Pack schema v1. "
+        f"Return exactly one JSON object for task `{task}` and satisfy its schema. "
         "Do not output markdown, code fences, or extra commentary. "
         f"Schema reference: {schema_path}."
     )
@@ -257,6 +268,7 @@ def _build_prompt_text(system_prompt: str, user_prompt: str) -> str:
 def build_sft_record(
     chunk: dict[str, Any],
     *,
+    task: str,
     split: str,
     format_name: str,
     max_context_chars: int,
@@ -276,8 +288,9 @@ def build_sft_record(
         "sha256": meta.get("sha256"),
         "locator": locator,
     }
-    output_json = build_study_pack_output(context)
+    output_json = build_output_by_task(task=task, context=context)
     system_prompt, user_prompt = build_prompts(
+        task=task,
         chunk_id=chunk_id,
         source_relative_path=source_relative_path,
         locator=locator,
@@ -286,9 +299,10 @@ def build_sft_record(
     )
 
     record: dict[str, Any] = {
-        "id": f"ins-{chunk_id}",
+        "id": f"ins-{task}-{chunk_id}",
         "dataset_version": DATASET_VERSION,
         "split": split,
+        "task": task,
         "chunk_id": chunk_id,
         "source": source,
         "meta": meta,
@@ -315,9 +329,10 @@ def build_dpo_record(sft_record: dict[str, Any]) -> dict[str, Any]:
     chosen_json = json.dumps(sft_record["output_json"], ensure_ascii=False)
     rejected_json = json.dumps({"schema_version": "1.0", "outline": []}, ensure_ascii=False)
     return {
-        "id": f"dpo-{sft_record['chunk_id']}",
+        "id": f"dpo-{sft_record['task']}-{sft_record['chunk_id']}",
         "dataset_version": PREFERENCE_DATASET_VERSION,
         "split": sft_record["split"],
+        "task": sft_record["task"],
         "prompt": prompt,
         "chosen": chosen_json,
         "rejected": rejected_json,
@@ -329,6 +344,7 @@ def build_dpo_record(sft_record: dict[str, Any]) -> dict[str, Any]:
 def build_instruction_records(
     *,
     chunks: list[dict[str, Any]],
+    task: str,
     split_spec: str,
     seed: int,
     max_context_chars: int,
@@ -338,6 +354,8 @@ def build_instruction_records(
 ) -> BuildResult:
     if format_name not in FORMAT_CHOICES:
         raise ValueError(f"unsupported format: {format_name}")
+    if task not in TASK_CHOICES:
+        raise ValueError(f"unsupported task: {task}")
 
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     validator = jsonschema.Draft202012Validator(schema)
@@ -348,10 +366,11 @@ def build_instruction_records(
     split_counts: dict[str, int] = {}
 
     for chunk in sorted(chunks, key=lambda item: str(item["chunk_id"])):
-        record_id = f"ins-{chunk['chunk_id']}"
+        record_id = f"ins-{task}-{chunk['chunk_id']}"
         split = assign_split(record_id=record_id, splits=split_definitions, seed=seed)
         sft_record = build_sft_record(
             chunk,
+            task=task,
             split=split,
             format_name=format_name,
             max_context_chars=max_context_chars,
@@ -421,6 +440,7 @@ def write_build_report(
             "input": args.input,
             "input_format": args.input_format,
             "study_pack_schema": str(args.study_pack_schema),
+            "task": args.task,
             "split": args.split,
             "seed": args.seed,
             "max_context_chars": args.max_context_chars,
@@ -465,7 +485,14 @@ def parse_args() -> argparse.Namespace:
         "--study-pack-schema",
         type=Path,
         default=DEFAULT_STUDY_PACK_SCHEMA,
-        help=f"Study Pack schema path (default: {DEFAULT_STUDY_PACK_SCHEMA})",
+        help=f"Domain task schema path (default: {DEFAULT_STUDY_PACK_SCHEMA})",
+    )
+    parser.add_argument(
+        "--task",
+        type=str,
+        choices=TASK_CHOICES,
+        default=TASK_DOMAIN,
+        help=f"Instruction task type (default: {TASK_DOMAIN})",
     )
     parser.add_argument(
         "--split",
@@ -510,6 +537,7 @@ def main() -> int:
 
         result = build_instruction_records(
             chunks=chunks,
+            task=args.task,
             split_spec=args.split,
             seed=args.seed,
             max_context_chars=args.max_context_chars,

--- a/backend/scripts/datasets/validate_instruction_dataset.py
+++ b/backend/scripts/datasets/validate_instruction_dataset.py
@@ -1,4 +1,4 @@
-"""Validate T4 instruction dataset JSONL against required fields and Study Pack schema."""
+"""Validate T4 instruction dataset JSONL against required fields and task-specific schemas."""
 
 from __future__ import annotations
 
@@ -13,10 +13,17 @@ import jsonschema
 
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_SCHEMA_PATH = (
+DEFAULT_DOMAIN_SCHEMA_PATH = (
     BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "study_pack.schema.v1.json"
 )
+DEFAULT_QUESTION_SCHEMA_PATH = (
+    BACKEND_ROOT / "docs" / "ai" / "question_v1" / "question_item.schema.v1.json"
+)
+DEFAULT_TUTOR_SCHEMA_PATH = (
+    BACKEND_ROOT / "docs" / "ai" / "tutor_v1" / "tutor_message.schema.v1.json"
+)
 DEFAULT_INPUT_PATH = BACKEND_ROOT / "datasets_local" / "exports"
+SUPPORTED_TASKS = ("domain", "question", "tutor")
 
 
 def utc_now_iso() -> str:
@@ -71,9 +78,16 @@ def validate_record_shape(record: Any) -> list[str]:
         return ["record must be a JSON object"]
 
     errors: list[str] = []
-    for field in ("id", "dataset_version", "split", "source", "chunk_id", "meta"):
+    for field in ("id", "dataset_version", "split", "task", "source", "chunk_id", "meta"):
         if field not in record:
             errors.append(f"missing required field: {field}")
+
+    task = record.get("task")
+    if "task" in record:
+        if not isinstance(task, str) or not task.strip():
+            errors.append("task must be a non-empty string")
+        elif task not in SUPPORTED_TASKS:
+            errors.append(f"task must be one of {SUPPORTED_TASKS}")
 
     if "source" in record:
         errors.extend(validate_source(record["source"]))
@@ -102,16 +116,30 @@ def validate_record_shape(record: Any) -> list[str]:
     return errors
 
 
+def _load_validator(schema_path: Path) -> jsonschema.Draft202012Validator:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    return jsonschema.Draft202012Validator(schema)
+
+
 def validate_instruction_dataset(
     *,
     input_path: Path,
-    schema_path: Path,
+    schema_path: Path | None = None,
+    domain_schema_path: Path | None = None,
+    question_schema_path: Path = DEFAULT_QUESTION_SCHEMA_PATH,
+    tutor_schema_path: Path = DEFAULT_TUTOR_SCHEMA_PATH,
     report_path: Path | None = None,
     quarantine_path: Path | None = None,
 ) -> dict[str, Any]:
     files = discover_dataset_files(input_path)
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
-    validator = jsonschema.Draft202012Validator(schema)
+    if domain_schema_path is None:
+        domain_schema_path = schema_path or DEFAULT_DOMAIN_SCHEMA_PATH
+
+    validators: dict[str, jsonschema.Draft202012Validator] = {
+        "domain": _load_validator(domain_schema_path),
+        "question": _load_validator(question_schema_path),
+        "tutor": _load_validator(tutor_schema_path),
+    }
 
     issues: list[dict[str, Any]] = []
     total_records = 0
@@ -139,10 +167,11 @@ def validate_instruction_dataset(
                 )
                 errors = parse_errors + validate_record_shape(record)
 
+                task_name = record.get("task") if isinstance(record, dict) else None
                 output_json = record.get("output_json") if isinstance(record, dict) else None
-                if isinstance(output_json, dict):
+                if isinstance(output_json, dict) and isinstance(task_name, str) and task_name in validators:
                     schema_errors = sorted(
-                        validator.iter_errors(output_json), key=lambda item: list(item.path)
+                        validators[task_name].iter_errors(output_json), key=lambda item: list(item.path)
                     )
                     for error in schema_errors:
                         path = ".".join(str(part) for part in error.path) or "<root>"
@@ -166,7 +195,11 @@ def validate_instruction_dataset(
         "version": "v1",
         "validated_at": utc_now_iso(),
         "input_path": str(input_path),
-        "schema_path": str(schema_path),
+        "schema_paths": {
+            "domain": str(domain_schema_path),
+            "question": str(question_schema_path),
+            "tutor": str(tutor_schema_path),
+        },
         "files": [str(path) for path in files],
         "total_records": total_records,
         "valid_records": valid_records,
@@ -208,9 +241,23 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--study-pack-schema",
+        "--domain-schema",
+        dest="domain_schema",
         type=Path,
-        default=DEFAULT_SCHEMA_PATH,
-        help=f"Study Pack schema path (default: {DEFAULT_SCHEMA_PATH})",
+        default=DEFAULT_DOMAIN_SCHEMA_PATH,
+        help=f"Domain schema path (default: {DEFAULT_DOMAIN_SCHEMA_PATH})",
+    )
+    parser.add_argument(
+        "--question-schema",
+        type=Path,
+        default=DEFAULT_QUESTION_SCHEMA_PATH,
+        help=f"Question schema path (default: {DEFAULT_QUESTION_SCHEMA_PATH})",
+    )
+    parser.add_argument(
+        "--tutor-schema",
+        type=Path,
+        default=DEFAULT_TUTOR_SCHEMA_PATH,
+        help=f"Tutor schema path (default: {DEFAULT_TUTOR_SCHEMA_PATH})",
     )
     parser.add_argument(
         "--report-path",
@@ -232,7 +279,9 @@ def main() -> int:
     try:
         report = validate_instruction_dataset(
             input_path=args.input,
-            schema_path=args.study_pack_schema,
+            domain_schema_path=args.domain_schema,
+            question_schema_path=args.question_schema,
+            tutor_schema_path=args.tutor_schema,
             report_path=args.report_path,
             quarantine_path=args.quarantine_path,
         )

--- a/backend/tests/scripts/test_build_instruction_dataset.py
+++ b/backend/tests/scripts/test_build_instruction_dataset.py
@@ -1,3 +1,4 @@
+# backend/tests/scripts/test_build_instruction_dataset.py
 import json
 from pathlib import Path
 
@@ -5,6 +6,7 @@ from scripts.datasets.build_instruction_dataset import (
     DATASET_VERSION,
     build_instruction_records,
     load_chunks_from_jsonl,
+    TASK_DOMAIN,
     write_split_jsonl,
 )
 
@@ -63,6 +65,7 @@ def test_build_instruction_dataset_from_jsonl_minimal(tmp_path) -> None:
 
     result = build_instruction_records(
         chunks=chunks,
+        task=TASK_DOMAIN,
         split_spec="train:0.67,valid:0.33",
         seed=42,
         max_context_chars=8000,
@@ -89,6 +92,7 @@ def test_build_instruction_dataset_from_jsonl_minimal(tmp_path) -> None:
         "id",
         "dataset_version",
         "split",
+        "task",
         "source",
         "chunk_id",
         "meta",
@@ -101,9 +105,11 @@ def test_build_instruction_dataset_from_jsonl_minimal(tmp_path) -> None:
         assert record["source"]["chunk_id"] == record["chunk_id"]
         assert isinstance(record["source"]["locator"], dict)
         assert record["dataset_version"] == DATASET_VERSION
+        assert record["task"] == TASK_DOMAIN
 
     same_seed_result = build_instruction_records(
         chunks=chunks,
+        task=TASK_DOMAIN,
         split_spec="train:0.67,valid:0.33",
         seed=42,
         max_context_chars=8000,

--- a/backend/tests/scripts/test_validate_instruction_dataset.py
+++ b/backend/tests/scripts/test_validate_instruction_dataset.py
@@ -5,7 +5,9 @@ from scripts.datasets.validate_instruction_dataset import validate_instruction_d
 
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
-SCHEMA_PATH = BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "study_pack.schema.v1.json"
+DOMAIN_SCHEMA_PATH = BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "study_pack.schema.v1.json"
+QUESTION_SCHEMA_PATH = BACKEND_ROOT / "docs" / "ai" / "question_v1" / "question_item.schema.v1.json"
+TUTOR_SCHEMA_PATH = BACKEND_ROOT / "docs" / "ai" / "tutor_v1" / "tutor_message.schema.v1.json"
 MINIMAL_VALID_PATH = (
     BACKEND_ROOT / "docs" / "ai" / "study_pack_v1" / "golden_samples" / "minimal_valid.json"
 )
@@ -18,11 +20,12 @@ def _write_jsonl(path: Path, rows: list[dict]) -> None:
             file_obj.write("\n")
 
 
-def _build_record(sample_id: str, output_json: dict) -> dict:
+def _build_record(sample_id: str, output_json: dict, *, task: str) -> dict:
     return {
         "id": sample_id,
         "dataset_version": "instruction_dataset.v1",
         "split": "train",
+        "task": task,
         "chunk_id": "ch-ds-fixture-000001",
         "source": {
             "doc_id": "doc-fixture-001",
@@ -47,14 +50,57 @@ def _build_record(sample_id: str, output_json: dict) -> dict:
     }
 
 
+def _question_output(*, include_evidence_refs: bool) -> dict:
+    payload = {
+        "question_id": "q-001",
+        "concept_id": "c-001",
+        "difficulty": "medium",
+        "stem": "Which concept best matches this paragraph?",
+        "answer_key": "A",
+        "rationale": "Because the definition aligns with the target concept.",
+    }
+    if include_evidence_refs:
+        payload["evidence_refs"] = [
+            {
+                "chunk_id": "ch-ds-fixture-000001",
+                "locator": {
+                    "source_file": "backend/datasets_local/raw/fixture.txt",
+                    "paragraph_start": 0,
+                    "paragraph_end": 0,
+                },
+            }
+        ]
+    return payload
+
+
+def _tutor_output(*, include_evidence_refs: bool) -> dict:
+    payload = {
+        "summary": "學生已完成一次作答。",
+        "feedback": "概念對齊不完整，需要再提示關鍵詞。",
+        "next_steps": ["回顧定義", "再做一題同概念題目"],
+    }
+    if include_evidence_refs:
+        payload["evidence_refs"] = [
+            {
+                "chunk_id": "ch-ds-fixture-000001",
+                "locator": {
+                    "source_file": "backend/datasets_local/raw/fixture.txt",
+                    "paragraph_start": 0,
+                    "paragraph_end": 0,
+                },
+            }
+        ]
+    return payload
+
+
 def test_validate_instruction_dataset_schema_ok(tmp_path) -> None:
     output_json = json.loads(MINIMAL_VALID_PATH.read_text(encoding="utf-8"))
     dataset_path = tmp_path / "instruction_dataset.v1.train.jsonl"
-    _write_jsonl(dataset_path, [_build_record("ins-ok-001", output_json)])
+    _write_jsonl(dataset_path, [_build_record("ins-ok-001", output_json, task="domain")])
 
     report = validate_instruction_dataset(
         input_path=dataset_path,
-        schema_path=SCHEMA_PATH,
+        schema_path=DOMAIN_SCHEMA_PATH,
     )
 
     assert report["total_records"] == 1
@@ -67,11 +113,14 @@ def test_validate_instruction_dataset_schema_fail_quarantine(tmp_path) -> None:
     invalid_output_json = {"schema_version": "1.0", "outline": []}
     dataset_path = tmp_path / "instruction_dataset.v1.train.jsonl"
     quarantine_path = tmp_path / "quarantine.jsonl"
-    _write_jsonl(dataset_path, [_build_record("ins-bad-001", invalid_output_json)])
+    _write_jsonl(
+        dataset_path,
+        [_build_record("ins-bad-001", invalid_output_json, task="domain")],
+    )
 
     report = validate_instruction_dataset(
         input_path=dataset_path,
-        schema_path=SCHEMA_PATH,
+        schema_path=DOMAIN_SCHEMA_PATH,
         quarantine_path=quarantine_path,
     )
 
@@ -92,3 +141,49 @@ def test_validate_instruction_dataset_schema_fail_quarantine(tmp_path) -> None:
             "line": 1,
         }
     ]
+
+
+def test_validate_instruction_dataset_question_tutor_missing_evidence_refs(tmp_path) -> None:
+    dataset_path = tmp_path / "instruction_dataset.v1.train.jsonl"
+    quarantine_path = tmp_path / "quarantine.jsonl"
+    _write_jsonl(
+        dataset_path,
+        [
+            _build_record(
+                "ins-question-bad-001",
+                _question_output(include_evidence_refs=False),
+                task="question",
+            ),
+            _build_record(
+                "ins-tutor-bad-001",
+                _tutor_output(include_evidence_refs=False),
+                task="tutor",
+            ),
+        ],
+    )
+
+    report = validate_instruction_dataset(
+        input_path=dataset_path,
+        domain_schema_path=DOMAIN_SCHEMA_PATH,
+        question_schema_path=QUESTION_SCHEMA_PATH,
+        tutor_schema_path=TUTOR_SCHEMA_PATH,
+        quarantine_path=quarantine_path,
+    )
+
+    assert report["total_records"] == 2
+    assert report["valid_records"] == 0
+    assert report["invalid_records"] == 2
+    assert set(report["invalid_ids"]) == {"ins-question-bad-001", "ins-tutor-bad-001"}
+
+    issue_map = {issue["id"]: issue for issue in report["issues"]}
+    assert "ins-question-bad-001" in issue_map
+    assert "ins-tutor-bad-001" in issue_map
+    assert any("evidence_refs" in error for error in issue_map["ins-question-bad-001"]["errors"])
+    assert any("evidence_refs" in error for error in issue_map["ins-tutor-bad-001"]["errors"])
+
+    quarantine_rows = [
+        json.loads(line)
+        for line in quarantine_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert {row["id"] for row in quarantine_rows} == {"ins-question-bad-001", "ins-tutor-bad-001"}

--- a/backend/tests/test_dataset_chunking.py
+++ b/backend/tests/test_dataset_chunking.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import jsonschema
 import yaml
 from docx import Document
 from pptx import Presentation
@@ -13,6 +14,7 @@ from pptx.util import Inches
 
 BASE = Path(__file__).resolve().parents[1]
 SCRIPT = BASE / "scripts" / "datasets" / "build_chunks.py"
+CHUNK_SCHEMA_PATH = BASE / "docs" / "ai" / "datasets" / "document_chunks.schema.v1.json"
 
 
 def _run_build_chunks(command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -60,6 +62,14 @@ def _read_jsonl(path: Path) -> list[dict]:
 
 def _sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _assert_records_follow_chunk_schema(records: list[dict]) -> None:
+    schema = json.loads(CHUNK_SCHEMA_PATH.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft202012Validator(schema)
+    for record in records:
+        errors = sorted(validator.iter_errors(record), key=lambda item: list(item.path))
+        assert not errors, f"{record['chunk_id']} schema errors: {[error.message for error in errors]}"
 
 
 def test_build_chunks_outputs_txt_docx_pptx_and_stats(tmp_path) -> None:
@@ -164,6 +174,11 @@ def test_build_chunks_outputs_txt_docx_pptx_and_stats(tmp_path) -> None:
     assert all(len(record["text"]) <= 120 for record in txt_records)
     assert all("paragraph_start" in record["meta"] for record in txt_records)
     assert all("paragraph_end" in record["meta"] for record in txt_records)
+    assert all("locator" in record["meta"] for record in txt_records)
+    assert all("source_file" in record["meta"]["locator"] for record in txt_records)
+    assert all("document_id" in record["meta"]["locator"] for record in txt_records)
+    assert all("paragraph_start" in record["meta"]["locator"] for record in txt_records)
+    assert all("paragraph_end" in record["meta"]["locator"] for record in txt_records)
     assert all(record["meta"]["source_relative_path"] == "backend/datasets_local/raw/notes.txt" for record in txt_records)
     assert all(record["meta"]["sha256"] == _sha256_file(txt_redacted_path) for record in txt_records)
     assert any("REDACTED paragraph" in record["text"] for record in txt_records)
@@ -173,6 +188,9 @@ def test_build_chunks_outputs_txt_docx_pptx_and_stats(tmp_path) -> None:
     assert docx_records
     assert all("paragraph_start" in record["meta"] for record in docx_records)
     assert all("paragraph_end" in record["meta"] for record in docx_records)
+    assert all("locator" in record["meta"] for record in docx_records)
+    assert all("paragraph_start" in record["meta"]["locator"] for record in docx_records)
+    assert all("paragraph_end" in record["meta"]["locator"] for record in docx_records)
     assert min(record["meta"]["paragraph_start"] for record in docx_records) == 0
     assert max(record["meta"]["paragraph_end"] for record in docx_records) >= 5
 
@@ -180,8 +198,12 @@ def test_build_chunks_outputs_txt_docx_pptx_and_stats(tmp_path) -> None:
     assert pptx_records
     assert all("slide_start" in record["meta"] for record in pptx_records)
     assert all("slide_end" in record["meta"] for record in pptx_records)
+    assert all("locator" in record["meta"] for record in pptx_records)
+    assert all("slide_index" in record["meta"]["locator"] for record in pptx_records)
     assert min(record["meta"]["slide_start"] for record in pptx_records) == 1
     assert max(record["meta"]["slide_end"] for record in pptx_records) >= 2
+
+    _assert_records_follow_chunk_schema(txt_records + docx_records + pptx_records)
 
     stats_path = out_dir / "chunk_stats.v1.json"
     stats = json.loads(stats_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
**Summary**

* 新增 Question/Tutor/Student 的 v1 schema 與簡短 README，補齊多 Agent 的輸出契約（T0）。
* chunks 產出強制包含來源定位 `meta.locator`，並在 `document_chunks.schema.v1.json` 變成必要欄位（T3）。
* instruction dataset 支援 `task` 欄位；validator 依 task 套用不同 schema，fail 進 quarantine 並產 report（T4/T5）。

**Why**

* 讓 Question/Tutor 的題目/回饋可以「回到原文」並可驗證，避免格式漂移與不可追溯輸出。

**How to test**

```bash
pytest -q

# (可選) end-to-end pipeline
python3 backend/scripts/datasets/build_chunks.py \
  --manifest backend/docs/ai/datasets/manifest.v1.yaml \
  --out-dir backend/datasets_local/exports/chunks

python3 backend/scripts/datasets/build_instruction_dataset.py \
  --input backend/datasets_local/exports/chunks \
  --input-format jsonl \
  --out-dir backend/datasets_local/exports \
  --study-pack-schema backend/docs/ai/study_pack_v1/study_pack.schema.v1.json \
  --task domain \
  --split train:0.9,valid:0.1 \
  --seed 42 \
  --max-context-chars 8000 \
  --format prompt_completion

python3 backend/scripts/datasets/validate_instruction_dataset.py \
  --input backend/datasets_local/exports \
  --domain-schema backend/docs/ai/study_pack_v1/study_pack.schema.v1.json \
  --question-schema backend/docs/ai/question_v1/question_item.schema.v1.json \
  --tutor-schema backend/docs/ai/tutor_v1/tutor_message.schema.v1.json
```

**Checklist**

* [x] `pytest -q` 全數通過
* [x] 未提交 `backend/datasets_local/*` 產物
* [x] chunks 每筆都有 `meta.locator`
* [x] validator 依 `task` 套 schema，invalid 會進 quarantine
